### PR TITLE
fix: add field name aliases for backward compatibility (closes #12)

### DIFF
--- a/api.py
+++ b/api.py
@@ -1479,6 +1479,14 @@ async def place_bet(market_id: str, req: BetRequest, user: dict = Depends(requir
     )
 
 
+# Alias: accept POST /markets/{id}/bets (plural) — redirects to the singular handler
+# Some SDKs/clients expect the plural form. Both work identically.
+@app.post("/markets/{market_id}/bets", response_model=BetResponse)
+async def place_bet_plural_alias(market_id: str, req: BetRequest, user: dict = Depends(require_auth)):
+    """Place a bet on a market (alias for POST /markets/{id}/bet)."""
+    return await place_bet(market_id, req, user)
+
+
 @app.post("/markets/{market_id}/sell", response_model=SellResponse)
 async def sell_shares(market_id: str, req: SellRequest, user: dict = Depends(require_auth)):
     """Sell shares back to the market."""

--- a/models.py
+++ b/models.py
@@ -7,7 +7,7 @@ Request/response schemas for markets, trading, and users.
 from datetime import datetime
 from enum import Enum
 from typing import Optional, Dict, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 # =============================================================================
@@ -30,11 +30,40 @@ class MarketStatus(str, Enum):
 # =============================================================================
 
 class MarketCreate(BaseModel):
-    """Request to create a new market."""
-    title: str = Field(..., min_length=5, max_length=500)
+    """Request to create a new market.
+    
+    Field aliases for backward compatibility:
+    - "question" is accepted as an alias for "title"
+    - "close_time" is accepted as an alias for "closes_at"
+    """
+    title: Optional[str] = Field(default=None, min_length=5, max_length=500)
+    question: Optional[str] = Field(default=None, min_length=5, max_length=500, exclude=True)
     description: str = Field(default="", max_length=5000)
-    closes_at: datetime
+    closes_at: Optional[datetime] = None
+    close_time: Optional[datetime] = Field(default=None, exclude=True)
     initial_liquidity: float = Field(default=100.0, ge=10.0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def apply_field_aliases(cls, data):
+        """Accept 'question' as alias for 'title' and 'close_time' as alias for 'closes_at'."""
+        if isinstance(data, dict):
+            # question -> title
+            if "question" in data and "title" not in data:
+                data["title"] = data["question"]
+            # close_time -> closes_at
+            if "close_time" in data and "closes_at" not in data:
+                data["closes_at"] = data["close_time"]
+        return data
+
+    @model_validator(mode="after")
+    def validate_required_fields(self):
+        """Ensure required fields are present (after alias resolution)."""
+        if not self.title:
+            raise ValueError("'title' (or 'question') is required")
+        if not self.closes_at:
+            raise ValueError("'closes_at' (or 'close_time') is required")
+        return self
 
 
 class MarketResolve(BaseModel):


### PR DESCRIPTION
## Summary

Fixes #12 — API field naming inconsistencies between endpoint names and what SDKs/clients expect.

## Changes

**All changes are additive — no existing behavior is modified.**

### 1. POST `/markets/{id}/bets` (plural alias)
Added a new route that delegates to the existing singular `/bet` handler. Both `POST /markets/{id}/bet` and `POST /markets/{id}/bets` now work identically.

### 2. `question` → `title` alias (market creation)
`MarketCreate` now accepts `"question"` as an alias for `"title"`. If a client sends `{"question": "Will X happen?"}`, it maps to `title` internally. If both are provided, `title` takes precedence.

### 3. `close_time` → `closes_at` alias (market creation)
`MarketCreate` now accepts `"close_time"` as an alias for `"closes_at"`. Same precedence rules apply.

## Files Changed
- **`models.py`** — Added `model_validator` to `MarketCreate` for field alias resolution
- **`api.py`** — Added `POST /markets/{id}/bets` route alias

## Testing
Verified all 6 scenarios locally:
- ✅ Original fields (`title`, `closes_at`) still work
- ✅ `question` maps to `title`
- ✅ `close_time` maps to `closes_at`
- ✅ Both aliases together work
- ✅ Original fields take precedence when both provided
- ✅ Missing required fields still correctly rejected