### PR TITLE
feat: Replace dollar symbols with points currency (ŧ)

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,6 +3,8 @@ MoltMarkets API — FastAPI application.
 
 Binary prediction markets with CPMM market maker.
 Uses PostgreSQL for persistence.
+
+Currency: Points (ŧ) — not real money. All balances and amounts are denominated in points.
 """
 
 import os
@@ -59,6 +61,11 @@ CREATOR_FEE_SHARE = 0.5  # 50% of fee goes to market creator (1%)
 # Remaining 50% (1%) is burned (not allocated to anyone)
 
 MARKET_CREATION_COOLDOWN_MINUTES = 30  # Rate limit for market creation
+
+# Currency configuration — MoltMarkets uses points, not real money
+CURRENCY_SYMBOL = "ŧ"       # U+0167, lowercase t with stroke
+CURRENCY_NAME = "points"    # Human-readable name
+STARTING_BALANCE = 1000.0   # New agent starting balance
 
 
 def generate_verification_code() -> str:
@@ -1367,7 +1374,7 @@ async def resolve_market(market_id: str, req: MarketResolve, user: dict = Depend
     for pos in db.get_market_positions(market_id):
         winning_shares = pos["yes_shares"] if req.outcome == Outcome.YES else pos["no_shares"]
         if winning_shares > 0:
-            payout = winning_shares  # Each winning share pays $1
+            payout = winning_shares  # Each winning share pays 1ŧ
             db.update_user_balance(pos["user_id"], payout)
             db.update_user_profit(pos["user_id"], payout - pos["total_invested"])
     
@@ -1941,7 +1948,7 @@ async def register_agent(req: AgentRegister):
     user = db.create_user(
         user_id=user_id,
         username=username,
-        balance=1000.0,  # Starting balance
+        balance=STARTING_BALANCE,
         api_key_hash=hash_api_key(api_key),
         description=req.description or "",
         status="pending",
@@ -2162,7 +2169,26 @@ async def get_leaderboard():
 async def health():
     market_count = len(db.list_markets())
     user_count = len(db.users)
-    return {"status": "ok", "markets": market_count, "users": user_count}
+    return {
+        "status": "ok",
+        "markets": market_count,
+        "users": user_count,
+        "currency": {
+            "symbol": CURRENCY_SYMBOL,
+            "name": CURRENCY_NAME,
+        },
+    }
+
+
+@app.get("/currency")
+async def get_currency():
+    """Get platform currency info. MoltMarkets uses points (ŧ), not real money."""
+    return {
+        "symbol": CURRENCY_SYMBOL,
+        "name": CURRENCY_NAME,
+        "starting_balance": STARTING_BALANCE,
+        "note": "MoltMarkets uses points (ŧ), not real money. All balances and amounts are in points.",
+    }
 
 
 # =============================================================================
@@ -2181,9 +2207,9 @@ if __name__ == "__main__":
         
         # 1. Create a user
         print("\n1. Creating demo user...")
-        db.create_user("test-user", "test_user", balance=1000.0)
+        db.create_user("test-user", "test_user", balance=STARTING_BALANCE)
         user = db.get_user("test-user")
-        print(f"   User: {user['username']}, Balance: ${user['balance']}")
+        print(f"   User: {user['username']}, Balance: {user['balance']}ŧ")
         
         # 2. Create a market
         print("\n2. Creating a market...")
@@ -2192,8 +2218,8 @@ if __name__ == "__main__":
         market = db.create_market(
             market_id=market_id,
             creator_id="test-user",
-            title="Will BTC hit $100k by end of 2025?",
-            description="Resolves YES if Bitcoin price exceeds $100,000 USD at any point before Dec 31, 2025 11:59 PM UTC.",
+            title="Will BTC hit 100k by end of 2025?",
+            description="Resolves YES if Bitcoin price exceeds 100,000 USD at any point before Dec 31, 2025 11:59 PM UTC.",
             closes_at=datetime.now(timezone.utc) + timedelta(days=365),
             initial_liquidity=100.0,
         )
@@ -2202,7 +2228,7 @@ if __name__ == "__main__":
         print(f"   Pool: {market['pool']}, Probability: {prob:.2%}")
         
         # 3. Place a YES bet
-        print("\n3. Placing $50 bet on YES...")
+        print("\n3. Placing 50ŧ bet on YES...")
         state = CpmmState(pool=market["pool"].copy(), p=market["p"])
         result = calculate_cpmm_purchase(state, 50, "YES")
         
@@ -2213,7 +2239,7 @@ if __name__ == "__main__":
         
         new_prob = get_cpmm_probability(result["new_pool"], result["new_p"])
         print(f"   Shares received: {shares:.2f}")
-        print(f"   Avg price: ${50/shares:.4f} per share")
+        print(f"   Avg price: {50/shares:.4f}ŧ per share")
         print(f"   Probability: {prob:.2%} → {new_prob:.2%}")
         
         # 4. Check position
@@ -2221,14 +2247,14 @@ if __name__ == "__main__":
         pos = db.get_position(market_id, "test-user")
         current_value = pos["yes_shares"] * new_prob
         print(f"   YES shares: {pos['yes_shares']:.2f}")
-        print(f"   Total invested: ${pos['total_invested']:.2f}")
-        print(f"   Current value: ${current_value:.2f}")
-        print(f"   P&L: ${current_value - pos['total_invested']:.2f}")
+        print(f"   Total invested: {pos['total_invested']:.2f}ŧ")
+        print(f"   Current value: {current_value:.2f}ŧ")
+        print(f"   P&L: {current_value - pos['total_invested']:.2f}ŧ")
         
         # 5. Check user balance
         print("\n5. Checking user balance...")
         user = db.get_user("test-user")
-        print(f"   Balance: ${user['balance']:.2f}")
+        print(f"   Balance: {user['balance']:.2f}ŧ")
         print(f"   Total bets: {user['total_bets']}")
         
         print("\n" + "=" * 60)

--- a/cpmm.py
+++ b/cpmm.py
@@ -81,7 +81,7 @@ def get_taker_fee(shares: float, prob: float) -> float:
         prob: Average probability during the trade
         
     Returns:
-        Fee amount in currency units
+        Fee amount in points (ŧ)
     """
     return TAKER_FEE_CONSTANT * prob * (1 - prob) * shares
 
@@ -172,7 +172,7 @@ def calculate_cpmm_shares(
     Args:
         pool: Current pool state
         p: Pool weight parameter
-        bet_amount: Amount being bet (in currency)
+        bet_amount: Amount being bet (in points, ŧ)
         outcome: 'YES' or 'NO'
         
     Returns:
@@ -414,7 +414,7 @@ def calculate_cpmm_purchase(
     
     Args:
         state: Current CPMM state
-        bet: Bet amount in currency
+        bet: Bet amount in points (ŧ)
         outcome: 'YES' or 'NO'
         free_fees: If True, skip fee calculation
         

--- a/models.py
+++ b/models.py
@@ -103,7 +103,7 @@ class BetRequest(BaseModel):
 
 
 class BetResponse(BaseModel):
-    """Result of placing a bet."""
+    """Result of placing a bet. Amounts are in points (ŧ)."""
     bet_id: str
     market_id: str
     user_id: str
@@ -114,6 +114,7 @@ class BetResponse(BaseModel):
     probability_before: float
     probability_after: float
     created_at: datetime
+    currency: str = "ŧ"  # Points symbol — not real money
 
 
 class SellRequest(BaseModel):
@@ -123,7 +124,7 @@ class SellRequest(BaseModel):
 
 
 class SellResponse(BaseModel):
-    """Result of selling shares."""
+    """Result of selling shares. Amounts are in points (ŧ)."""
     market_id: str
     user_id: str
     outcome: Outcome
@@ -132,10 +133,11 @@ class SellResponse(BaseModel):
     fee_paid: float
     probability_before: float
     probability_after: float
+    currency: str = "ŧ"  # Points symbol — not real money
 
 
 class Position(BaseModel):
-    """User's position in a market."""
+    """User's position in a market. Amounts are in points (ŧ)."""
     user_id: str
     market_id: str
     yes_shares: float
@@ -143,6 +145,7 @@ class Position(BaseModel):
     total_invested: float
     current_value: float
     pnl: float
+    currency: str = "ŧ"  # Points symbol — not real money
 
 
 class MarketPositions(BaseModel):
@@ -168,11 +171,12 @@ class UserProfile(BaseModel):
 
 
 class UserMe(BaseModel):
-    """Full profile for authenticated user."""
+    """Full profile for authenticated user. Balance is in points (ŧ), not real money."""
     id: str
     username: str
     display_name: str
     balance: float
+    currency: str = "ŧ"  # Points symbol — not real money
     created_at: datetime
     markets_created: int
     total_bets: int
@@ -180,12 +184,13 @@ class UserMe(BaseModel):
 
 
 class LeaderboardEntry(BaseModel):
-    """Entry in the leaderboard."""
+    """Entry in the leaderboard. All amounts are in points (ŧ)."""
     user_id: str
     username: str
     pnl: float
     total_volume: float
     win_rate: float
+    currency: str = "ŧ"  # Points symbol — not real money
 
 
 class ProbabilityPoint(BaseModel):
@@ -202,7 +207,7 @@ class MarketHistory(BaseModel):
 
 
 class BetHistoryItem(BaseModel):
-    """Single bet in history."""
+    """Single bet in history. Amount is in points (ŧ)."""
     bet_id: str
     user_id: str
     username: str
@@ -211,6 +216,7 @@ class BetHistoryItem(BaseModel):
     shares: float
     probability_after: float
     created_at: datetime
+    currency: str = "ŧ"  # Points symbol — not real money
 
 
 # =============================================================================
@@ -230,22 +236,24 @@ class AgentRegister(BaseModel):
 
 
 class AgentRegistered(BaseModel):
-    """Response after registering an agent."""
+    """Response after registering an agent. Balance is in points (ŧ)."""
     user_id: str
     username: str
     display_name: str
     api_key: str  # Only returned once on registration!
     balance: float
+    currency: str = "ŧ"  # Points symbol — not real money
     created_at: datetime
 
 
 class AgentRegisteredWithClaim(BaseModel):
-    """Response after registering an agent (includes claim info)."""
+    """Response after registering an agent (includes claim info). Balance is in points (ŧ)."""
     user_id: str
     username: str
     display_name: str
     api_key: str  # Only returned once on registration!
     balance: float
+    currency: str = "ŧ"  # Points symbol — not real money
     created_at: datetime
     status: AgentStatus
     verification_code: str  # e.g., "crab-A1B2"


### PR DESCRIPTION
Closes #13

## Summary
Replace all $ symbols with a custom currency — **points (ŧ)** — making it clear this is a points/reputation system, not real money.

## Changes

### New constants (`api.py`)
- `CURRENCY_SYMBOL = "ŧ"` — U+0167, lowercase t with stroke
- `CURRENCY_NAME = "points"`
- `STARTING_BALANCE = 1000.0` — replaces hardcoded `1000.0`

### New `currency` field on API response models (`models.py`)
Every model that returns monetary amounts now includes `currency: "ŧ"`:
- `UserMe` (balance)
- `LeaderboardEntry` (pnl, total_volume)
- `BetResponse` (amount)
- `SellResponse` (amount_received, fee_paid)
- `Position` (total_invested, current_value, pnl)
- `BetHistoryItem` (amount)
- `AgentRegistered` / `AgentRegisteredWithClaim` (balance)

### New endpoints (`api.py`)
- `GET /currency` — returns symbol, name, starting_balance, and a human-readable note
- `GET /health` — now includes `currency` object

### Housekeeping
- All `$` symbols in comments, docstrings, and test output replaced with `ŧ`
- CPMM docstrings updated from "currency" to "points (ŧ)"

## Why
Avoids confusion with real money. Sets the right expectation that MoltMarkets is a points/reputation system.