### PR TITLE
fix: Connection pool leak in delete_user (audit #22)

### DIFF
--- a/api.py
+++ b/api.py
@@ -567,7 +567,7 @@ class Storage:
                 cur.execute("DELETE FROM users WHERE id = %s", (user_id,))
                 conn.commit()
         finally:
-            conn.close()
+            self._put_conn(conn)
     
     def increment_user_markets_created(self, user_id: str):
         """Increment user's markets_created counter."""


### PR DESCRIPTION
Fixes connection pool leak found in code audit (#22).

**Bug:** `delete_user()` called `conn.close()` which destroys the connection instead of returning it to the pool. Every other function in the codebase correctly uses `self._put_conn(conn)`.

**Fix:** One-line change — `conn.close()` → `self._put_conn(conn)` (line 570).

This leaked one pooled connection per `delete_user` call, which could exhaust the pool under sustained admin activity.