### PR TITLE
fix: Filter resolved markets from default listing (#27)

### DIFF
--- a/api.py
+++ b/api.py
@@ -1223,9 +1223,26 @@ app.add_middleware(
 # =============================================================================
 
 @app.get("/markets", response_model=List[MarketSummary])
-async def list_markets():
-    """List all markets."""
+async def list_markets(status: Optional[str] = None):
+    """List markets, filtered by status.
+
+    Query params:
+        status: Filter by market status.
+            - omitted or "open" → only OPEN markets (default)
+            - "all"             → all markets regardless of status
+            - "resolved"        → only RESOLVED markets
+    """
     markets = db.list_markets()
+
+    # Apply status filter (default: only open markets)
+    status_filter = (status or "open").strip().upper()
+    if status_filter == "ALL":
+        pass  # no filtering
+    elif status_filter == "RESOLVED":
+        markets = [m for m in markets if m["status"] == MarketStatus.RESOLVED]
+    else:
+        # Default: only open markets
+        markets = [m for m in markets if m["status"] == MarketStatus.OPEN]
     result = []
     for m in markets:
         # Look up creator username


### PR DESCRIPTION
## Summary
The `GET /markets` endpoint was returning all markets including resolved ones. This adds a default filter so only **OPEN** markets are returned unless a `status` query param is passed.

## Changes
- Default (no param or `?status=open`): returns only OPEN markets
- `?status=all`: returns all markets regardless of status
- `?status=resolved`: returns only RESOLVED markets

## Why
Active traders shouldn't have to wade through resolved markets. The default experience should show what's tradeable now.

Closes #27