### PR TITLE
fix: Add currency field to markets endpoints (#31)

### DIFF
--- a/models.py
+++ b/models.py
@@ -81,6 +81,7 @@ class MarketSummary(BaseModel):
     total_volume: float
     creator_id: str
     creator_username: Optional[str] = None
+    currency: str = "ŧ"
 
 
 class MarketDetail(BaseModel):
@@ -99,6 +100,7 @@ class MarketDetail(BaseModel):
     creator_username: Optional[str] = None
     pool: Dict[str, float]  # YES/NO pool amounts
     p: float  # CPMM p parameter
+    currency: str = "ŧ"
 
 
 class MarketCreated(BaseModel):


### PR DESCRIPTION
Adds currency field to market list and detail responses, consistent with /me and /currency endpoints. Closes #31.