### PR TITLE
feat: Rate limiting + max bet amount (#16, #10)

### DIFF
--- a/api.py
+++ b/api.py
@@ -15,11 +15,12 @@ from typing import Dict, List, Optional
 from contextlib import asynccontextmanager
 from urllib.parse import urlparse, unquote
 
-from fastapi import FastAPI, HTTPException, Depends, Header
+from fastapi import FastAPI, HTTPException, Depends, Header, Request
 from fastapi.middleware.cors import CORSMiddleware
 import httpx
 
 from cpmm import CpmmState, calculate_cpmm_purchase, calculate_cpmm_sale, get_cpmm_probability, Outcome as CpmmOutcome
+from rate_limiter import rate_limiter, MAX_REGISTRATIONS_PER_HOUR, MAX_BETS_PER_MINUTE, MAX_BET_AMOUNT
 import secrets
 import hashlib
 import psycopg2
@@ -1428,7 +1429,11 @@ async def resolve_market(market_id: str, req: MarketResolve, user: dict = Depend
 
 @app.post("/markets/{market_id}/bet", response_model=BetResponse)
 async def place_bet(market_id: str, req: BetRequest, user: dict = Depends(require_auth)):
-    """Place a bet on a market."""
+    """Place a bet on a market.
+    
+    Rate limited: max 30 bets per agent per minute.
+    Max bet amount: 500ŧ per single bet.
+    """
     # Require twitter verification before trading
     if user.get("status") != "claimed":
         raise HTTPException(
@@ -1436,6 +1441,25 @@ async def place_bet(market_id: str, req: BetRequest, user: dict = Depends(requir
             detail="Twitter verification required before trading. Visit /claim/{user_id} to link your Twitter account."
         )
     
+    # ── Max bet amount ──
+    if req.amount > MAX_BET_AMOUNT:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Bet amount {req.amount}ŧ exceeds maximum of {MAX_BET_AMOUNT}ŧ per bet.",
+        )
+
+    # ── Rate limit: bets per agent ──
+    allowed, info = rate_limiter.check(
+        f"bet:{user['id']}",
+        max_requests=MAX_BETS_PER_MINUTE,
+        window_seconds=60,
+    )
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Betting rate limit exceeded ({MAX_BETS_PER_MINUTE}/minute). {info['detail']}",
+        )
+
     market = db.get_market(market_id)
     if not market:
         raise HTTPException(status_code=404, detail="Market not found")
@@ -1952,7 +1976,7 @@ async def get_user(user_id: str):
 # =============================================================================
 
 @app.post("/agents/register", response_model=AgentRegisteredWithClaim)
-async def register_agent(req: AgentRegister):
+async def register_agent(req: AgentRegister, request: Request):
     """
     Register a new agent and get an API key.
     
@@ -1960,7 +1984,22 @@ async def register_agent(req: AgentRegister):
     
     Returns a verification_code and claim_url for human-agent linking.
     The human must tweet the verification code to claim the agent.
+    
+    Rate limited: max 5 registrations per IP per hour.
     """
+    # ── Rate limit: registrations per IP ──
+    client_ip = request.client.host if request.client else "unknown"
+    allowed, info = rate_limiter.check(
+        f"register:{client_ip}",
+        max_requests=MAX_REGISTRATIONS_PER_HOUR,
+        window_seconds=3600,
+    )
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Registration rate limit exceeded ({MAX_REGISTRATIONS_PER_HOUR}/hour per IP). {info['detail']}",
+        )
+
     # Normalize username to lowercase (case-insensitive uniqueness)
     username = req.username.lower()
     

--- a/models.py
+++ b/models.py
@@ -126,9 +126,9 @@ class MarketCreated(BaseModel):
 # =============================================================================
 
 class BetRequest(BaseModel):
-    """Request to place a bet."""
+    """Request to place a bet. Max 500ŧ per bet."""
     outcome: Outcome
-    amount: float = Field(..., gt=0, le=1_000_000)
+    amount: float = Field(..., gt=0, le=500, description="Bet amount in ŧ (max 500)")
 
 
 class BetResponse(BaseModel):

--- a/rate_limiter.py
+++ b/rate_limiter.py
@@ -1,0 +1,108 @@
+"""
+In-memory rate limiter for MoltMarkets API.
+
+Tracks request counts per key (IP address, agent ID, etc.) within
+sliding time windows. No external dependencies — uses a simple dict
+with periodic cleanup.
+
+Thread-safe enough for single-process uvicorn (the default deployment).
+For multi-worker deployments, switch to Redis-backed rate limiting.
+"""
+
+import time
+from collections import defaultdict
+from threading import Lock
+from typing import Tuple
+
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+MAX_REGISTRATIONS_PER_HOUR = 5    # Per IP address
+MAX_BETS_PER_MINUTE = 30          # Per agent (user_id)
+MAX_BET_AMOUNT = 500              # Max single bet in ŧ (points)
+
+# Cleanup runs every N calls to avoid unbounded memory growth
+_CLEANUP_INTERVAL = 100
+
+
+# ── Rate Limiter ─────────────────────────────────────────────────────────────
+
+class RateLimiter:
+    """
+    Sliding-window rate limiter backed by an in-memory dict.
+
+    Each key (e.g. IP or user_id) maps to a list of Unix timestamps.
+    On every check we prune timestamps outside the window, then decide
+    whether the request should be allowed.
+
+    Usage:
+        limiter = RateLimiter()
+        allowed, info = limiter.check("reg:1.2.3.4", max_requests=5, window_seconds=3600)
+        if not allowed:
+            raise HTTPException(429, detail=info["detail"])
+    """
+
+    def __init__(self):
+        self._requests: dict[str, list[float]] = defaultdict(list)
+        self._lock = Lock()
+        self._call_count = 0
+
+    def check(self, key: str, max_requests: int, window_seconds: int) -> Tuple[bool, dict]:
+        """
+        Check whether a request identified by *key* is within limits.
+
+        Returns:
+            (allowed, info)
+            - allowed: True if under the limit, False if rate-limited.
+            - info: dict with "remaining", "reset_in", and "detail" (human-readable).
+        """
+        now = time.time()
+        cutoff = now - window_seconds
+
+        with self._lock:
+            # Prune old entries for this key
+            timestamps = self._requests[key]
+            self._requests[key] = [t for t in timestamps if t > cutoff]
+            timestamps = self._requests[key]
+
+            count = len(timestamps)
+            remaining = max(0, max_requests - count)
+
+            if count >= max_requests:
+                # Find when the oldest entry expires
+                oldest = min(timestamps) if timestamps else now
+                reset_in = round(oldest + window_seconds - now, 1)
+                return False, {
+                    "remaining": 0,
+                    "reset_in": max(0, reset_in),
+                    "detail": f"Rate limit exceeded. Try again in {max(1, int(reset_in))}s.",
+                }
+
+            # Allow — record this request
+            self._requests[key].append(now)
+            self._call_count += 1
+
+            # Periodic full cleanup (remove keys with no recent entries)
+            if self._call_count % _CLEANUP_INTERVAL == 0:
+                self._cleanup(now)
+
+            return True, {
+                "remaining": remaining - 1,
+                "reset_in": 0,
+                "detail": "",
+            }
+
+    def _cleanup(self, now: float):
+        """Remove keys whose entries have all expired (oldest window = 1 hour)."""
+        max_window = 3600  # Longest window we support
+        cutoff = now - max_window
+        stale_keys = [k for k, ts in self._requests.items() if all(t <= cutoff for t in ts)]
+        for k in stale_keys:
+            del self._requests[k]
+
+
+# ── Singleton ────────────────────────────────────────────────────────────────
+# One global instance shared across the app. Resets on process restart,
+# which is fine for a single-process deployment.
+
+rate_limiter = RateLimiter()


### PR DESCRIPTION
## What

Adds in-memory rate limiting for registration and betting, plus a max bet cap.

### Changes

1. **Registration rate limit** — Max 5 registrations per IP per hour (HTTP 429)
2. **Betting rate limit** — Max 30 bets per agent per minute (HTTP 429)
3. **Max bet amount** — No single bet can exceed 500ŧ (HTTP 400 + schema `le=500`)

### Implementation

- New `rate_limiter.py`: sliding-window in-memory rate limiter using a dict of timestamps per key. Periodic cleanup prevents unbounded memory growth. No external dependencies (no Redis).
- Constants: `MAX_REGISTRATIONS_PER_HOUR = 5`, `MAX_BETS_PER_MINUTE = 30`, `MAX_BET_AMOUNT = 500`
- `BetRequest` model updated: `le=1_000_000` → `le=500`

### Files changed

| File | Change |
|------|--------|
| `rate_limiter.py` | New — RateLimiter class + constants |
| `api.py` | Rate-limit checks on `/agents/register` and `/markets/{id}/bet` |
| `models.py` | BetRequest amount cap lowered to 500 |

Closes #16, closes #10.