### PR TITLE
fix: connection pool stability — keepalives, validation, and error recovery (#40)

### DIFF
--- a/api.py
+++ b/api.py
@@ -201,7 +201,12 @@ class Storage:
             self._positions: Dict[str, Dict[str, dict]] = {}
     
     def _init_pool(self):
-        """Initialize the connection pool."""
+        """Initialize the connection pool.
+        
+        Configures TCP keepalives so Railway's Postgres proxy doesn't silently
+        drop idle connections, and sets a statement timeout as a safety net
+        against queries that hang forever.
+        """
         parsed = urlparse(self.database_url)
         self._pool = pool.SimpleConnectionPool(
             minconn=1,
@@ -211,16 +216,58 @@ class Storage:
             user=parsed.username,
             password=unquote(parsed.password) if parsed.password else None,
             dbname=parsed.path.lstrip('/'),
-            cursor_factory=RealDictCursor
+            cursor_factory=RealDictCursor,
+            connect_timeout=10,          # Don't wait forever to connect
+            keepalives=1,                # Enable TCP keepalives
+            keepalives_idle=30,          # Send keepalive after 30s idle
+            keepalives_interval=10,      # Retry keepalive every 10s
+            keepalives_count=3,          # Give up after 3 missed keepalives
+            options='-c statement_timeout=30000',  # 30s query timeout
         )
-        print("Connection pool initialized (min=1, max=10)")
+        print("Connection pool initialized (min=1, max=10, keepalives=on, statement_timeout=30s)")
     
     def _get_conn(self):
-        """Get a database connection from the pool."""
-        return self._pool.getconn()
+        """Get a database connection from the pool.
+        
+        Validates the connection is alive before returning it.  If the
+        connection is dead (e.g., closed by Railway's proxy), it is discarded
+        and a fresh one is created.
+        """
+        conn = self._pool.getconn()
+        try:
+            # Quick health check — if the connection was silently closed
+            # by the proxy/firewall, this will raise an exception.
+            conn.isolation_level  # Triggers a round-trip if connection is bad
+            if conn.closed:
+                raise psycopg2.OperationalError("connection is closed")
+            # Run a trivial query to truly verify the connection is live
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+        except Exception:
+            # Connection is dead — discard it and get a fresh one
+            try:
+                self._pool.putconn(conn, close=True)
+            except Exception:
+                pass
+            conn = self._pool.getconn()
+        return conn
     
     def _put_conn(self, conn):
-        """Return a connection to the pool."""
+        """Return a connection to the pool.
+        
+        Always rolls back any uncommitted transaction first so the next
+        user of this connection doesn't inherit a broken transaction state
+        (InFailedSqlTransaction).
+        """
+        try:
+            conn.rollback()  # Clean slate — no stale transaction state
+        except Exception:
+            # Connection is broken beyond repair — close instead of returning
+            try:
+                self._pool.putconn(conn, close=True)
+            except Exception:
+                pass
+            return
         self._pool.putconn(conn)
     
     def _init_db(self):


### PR DESCRIPTION
## Summary

Fixes #40 — API stops responding after ~2 hours of active use.

## Root Cause Analysis

After reading the full codebase, I identified **three compounding issues** that together cause the outage:

### 1. Stale connections from Railway's Postgres proxy (PRIMARY)
`SimpleConnectionPool` has **no TCP keepalives** configured. Railway's Postgres proxy (and intermediate firewalls/load balancers) silently close idle TCP connections after a timeout period. The pool has no idea these connections are dead.

When the server grabs a dead connection, the synchronous `psycopg2` query **hangs indefinitely** waiting for a response that will never come. Since the DB calls block the async event loop, the entire server freezes — no request can be processed until the TCP timeout fires (which can take minutes).

### 2. Transaction state poisoning (SECONDARY)
Every `Storage` method follows this pattern:
```python
conn = self._get_conn()
try:
    cur.execute(...)
    conn.commit()
finally:
    self._put_conn(conn)  # Returns connection as-is
```
If any operation raises an exception (constraint violation, timeout, etc.), the connection is returned with a **broken transaction** still open. The next user of that connection gets `InFailedSqlTransaction` on every query. Over time, more connections become poisoned → cascading failures.

### 3. No query timeout safety net
Without `statement_timeout`, a single slow query (e.g., during a Postgres vacuum or Railway maintenance) blocks the event loop forever.

## Fix (53 lines changed in `api.py`)

| Change | What it does |
|--------|-------------|
| `keepalives=1, keepalives_idle=30` | TCP keepalive probes every 30s prevent proxy from dropping idle connections |
| `connect_timeout=10` | Fail fast on unreachable DB instead of hanging |
| `statement_timeout=30000` | Kill queries that take >30s instead of blocking forever |
| `_get_conn()` health check | `SELECT 1` on checkout; dead connections are discarded and replaced |
| `_put_conn()` auto-rollback | Cleans up any failed transaction state before returning to pool |
| Broken connection handling | Connections that can't even rollback are closed, not returned |

## Why this explains the exact symptoms

- **"Works fine, then times out after ~2 hours"** — connections idle during low-activity periods get killed by the proxy. Next request grabs a dead connection and hangs.
- **"TLS completes but 0 bytes returned"** — uvicorn accepts the TCP connection (TLS works) but the event loop is blocked on a dead DB connection, so the HTTP response is never generated.
- **"All endpoints affected simultaneously"** — single-threaded event loop means one blocked DB call freezes everything.

## Prior art
This repo already had a connection pool fix (commit `c607fef` — replacing `conn.close()` with `_put_conn()`). This PR addresses the remaining failure modes.

## Future considerations (not in this PR)
- **Migrate to async DB driver** (asyncpg or psycopg3 async) — would prevent DB calls from blocking the event loop entirely
- **Switch to `ThreadedConnectionPool`** — if multiple uvicorn workers are ever used
- **Add a `/health` DB ping** — Railway health checks could auto-restart on DB connectivity loss