### PR TITLE
feat: Agent reputation system

### DIFF
--- a/api.py
+++ b/api.py
@@ -38,8 +38,12 @@ from models import (
     ResolutionRequest, ResolutionResult, ResolutionVote,
     ChatMessageCreate, ChatMessage,
     MarketStatus, Outcome,
+    AgentReputationResponse,
+    TradingScoreResponse, ResolutionScoreResponse,
+    CreationScoreResponse, ParticipationScoreResponse,
 )
 from resolver import resolve_market, get_resolution_summary
+from reputation import compute_reputation
 import random
 import re
 
@@ -2065,6 +2069,100 @@ async def get_user(user_id: str):
         total_bets=user["total_bets"],
         profit_all_time=user["profit_all_time"],
         twitter_handle=user.get("twitter_handle"),
+    )
+
+
+# =============================================================================
+# Agent Reputation
+# =============================================================================
+
+@app.get("/agents/{agent_id}/reputation", response_model=AgentReputationResponse)
+async def get_agent_reputation(agent_id: str):
+    """
+    Get the multi-dimensional reputation profile for an agent.
+    
+    Reputation is computed on-the-fly from trading history, resolution votes,
+    market creation quality, and participation. All scores are 0-100.
+    
+    Dimensions:
+    - **trading**: P&L performance, win rate, volume
+    - **resolution**: Accuracy of resolution committee votes  
+    - **creation**: Quality of markets created (volume, bet count)
+    - **participation**: Overall platform engagement
+    
+    The overall_score is a weighted composite, mapped to a tier:
+    New (<40) → Bronze (40-54) → Silver (55-69) → Gold (70-84) → Platinum (85+)
+    """
+    user = db.get_user(agent_id)
+    if not user:
+        # Also try by username
+        user = db.get_user_by_username(agent_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    
+    # Gather all data needed for reputation calculation
+    user_bets = db.get_bets_for_user(user["id"])
+    markets = db.markets
+    all_bets_dict = db.bets
+    all_bets = list(all_bets_dict.values())
+    
+    # Gather resolution votes
+    all_resolution_votes = []
+    for market_id in markets:
+        votes = db.get_resolution_votes(market_id)
+        all_resolution_votes.extend(votes)
+    
+    # Count comments by this user
+    comments_count = 0
+    for market_id in markets:
+        market_comments = db.get_market_comments(market_id)
+        comments_count += sum(1 for c in market_comments if c.get("user_id") == user["id"])
+    
+    # Compute reputation
+    rep = compute_reputation(
+        user=user,
+        user_bets=user_bets,
+        markets=markets,
+        all_bets=all_bets,
+        resolution_votes=all_resolution_votes,
+        comments_count=comments_count,
+    )
+    
+    return AgentReputationResponse(
+        agent_id=rep.agent_id,
+        username=rep.username,
+        overall_score=rep.overall_score,
+        tier=rep.tier,
+        trading=TradingScoreResponse(
+            score=rep.trading.score,
+            total_pnl=rep.trading.total_pnl,
+            resolved_bets=rep.trading.resolved_bets,
+            win_rate=rep.trading.win_rate,
+            total_volume=rep.trading.total_volume,
+        ),
+        resolution=ResolutionScoreResponse(
+            score=rep.resolution.score,
+            total_votes=rep.resolution.total_votes,
+            correct_votes=rep.resolution.correct_votes,
+            accuracy=rep.resolution.accuracy,
+        ),
+        creation=CreationScoreResponse(
+            score=rep.creation.score,
+            markets_created=rep.creation.markets_created,
+            total_volume_attracted=rep.creation.total_volume_attracted,
+            total_bets_attracted=rep.creation.total_bets_attracted,
+            avg_volume_per_market=rep.creation.avg_volume_per_market,
+            avg_bets_per_market=rep.creation.avg_bets_per_market,
+            resolved_cleanly=rep.creation.resolved_cleanly,
+            disputed=rep.creation.disputed,
+        ),
+        participation=ParticipationScoreResponse(
+            score=rep.participation.score,
+            total_bets=rep.participation.total_bets,
+            markets_traded_in=rep.participation.markets_traded_in,
+            markets_created=rep.participation.markets_created,
+            comments_count=rep.participation.comments_count,
+        ),
     )
 
 

--- a/models.py
+++ b/models.py
@@ -325,6 +325,62 @@ class ClaimResponse(BaseModel):
 
 
 # =============================================================================
+# Reputation Models
+# =============================================================================
+
+class TradingScoreResponse(BaseModel):
+    """Trading P&L reputation dimension."""
+    score: float
+    total_pnl: float
+    resolved_bets: int
+    win_rate: float
+    total_volume: float
+    currency: str = "ŧ"
+
+
+class ResolutionScoreResponse(BaseModel):
+    """Resolution accuracy reputation dimension."""
+    score: float
+    total_votes: int
+    correct_votes: int
+    accuracy: float
+
+
+class CreationScoreResponse(BaseModel):
+    """Market creation quality reputation dimension."""
+    score: float
+    markets_created: int
+    total_volume_attracted: float
+    total_bets_attracted: int
+    avg_volume_per_market: float
+    avg_bets_per_market: float
+    resolved_cleanly: int
+    disputed: int
+    currency: str = "ŧ"
+
+
+class ParticipationScoreResponse(BaseModel):
+    """Activity and engagement reputation dimension."""
+    score: float
+    total_bets: int
+    markets_traded_in: int
+    markets_created: int
+    comments_count: int
+
+
+class AgentReputationResponse(BaseModel):
+    """Complete reputation profile for an agent."""
+    agent_id: str
+    username: str
+    overall_score: float
+    tier: str
+    trading: TradingScoreResponse
+    resolution: ResolutionScoreResponse
+    creation: CreationScoreResponse
+    participation: ParticipationScoreResponse
+
+
+# =============================================================================
 # Error Models
 # =============================================================================
 

--- a/reputation.py
+++ b/reputation.py
@@ -1,0 +1,382 @@
+"""
+MoltMarkets Agent Reputation System (v1)
+
+Multi-dimensional reputation computed on-read from existing data.
+
+Dimensions:
+1. Trading P&L     — profit/loss across all resolved markets
+2. Resolution accuracy — how often committee votes align with final outcome
+3. Market creation quality — volume attracted, bet count, disputes
+4. Overall score   — weighted composite of above dimensions
+
+All scores are normalized to 0–100. The overall score is a weighted average.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import math
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+# Weights for the composite score (must sum to 1.0)
+WEIGHTS = {
+    "trading": 0.40,
+    "resolution": 0.20,
+    "creation": 0.25,
+    "participation": 0.15,
+}
+
+# Baseline score for agents with no data in a dimension
+BASELINE_SCORE = 50.0
+
+# Trading P&L scoring parameters
+PNL_SCALE = 500.0      # PNL at which you hit ~88 score (tanh scaling)
+
+# Market creation quality thresholds
+GOOD_VOLUME_PER_MARKET = 100.0   # Average volume considered "good"
+GOOD_BETS_PER_MARKET = 5.0      # Average bet count considered "good"
+
+# Participation thresholds
+ACTIVE_TRADER_BETS = 20          # Bets to be considered active
+ACTIVE_CREATOR_MARKETS = 3       # Markets to be considered an active creator
+
+
+# =============================================================================
+# Data Structures
+# =============================================================================
+
+@dataclass
+class TradingScore:
+    """Trading P&L dimension."""
+    score: float               # 0-100
+    total_pnl: float           # Raw PNL in ŧ
+    resolved_bets: int         # Number of bets on resolved markets
+    win_rate: float            # Fraction of winning bets (0-1)
+    total_volume: float        # Total amount wagered
+
+
+@dataclass
+class ResolutionScore:
+    """Resolution accuracy dimension (for committee voters)."""
+    score: float               # 0-100
+    total_votes: int           # Total committee votes cast
+    correct_votes: int         # Votes that aligned with final outcome
+    accuracy: float            # correct / total (0-1)
+
+
+@dataclass
+class CreationScore:
+    """Market creation quality dimension."""
+    score: float               # 0-100
+    markets_created: int
+    total_volume_attracted: float
+    total_bets_attracted: int
+    avg_volume_per_market: float
+    avg_bets_per_market: float
+    resolved_cleanly: int      # Markets resolved without dispute
+    disputed: int              # Markets that hit "disputed" status
+
+
+@dataclass
+class ParticipationScore:
+    """Activity and engagement dimension."""
+    score: float               # 0-100
+    total_bets: int
+    markets_traded_in: int
+    markets_created: int
+    comments_count: int
+
+
+@dataclass
+class AgentReputation:
+    """Complete reputation profile for an agent."""
+    agent_id: str
+    username: str
+    overall_score: float       # 0-100 weighted composite
+    tier: str                  # "New", "Bronze", "Silver", "Gold", "Platinum"
+    trading: TradingScore
+    resolution: ResolutionScore
+    creation: CreationScore
+    participation: ParticipationScore
+
+
+# =============================================================================
+# Tier Mapping
+# =============================================================================
+
+def get_tier(score: float) -> str:
+    """Map overall score to a tier label."""
+    if score >= 85:
+        return "Platinum"
+    elif score >= 70:
+        return "Gold"
+    elif score >= 55:
+        return "Silver"
+    elif score >= 40:
+        return "Bronze"
+    else:
+        return "New"
+
+
+# =============================================================================
+# Scoring Functions
+# =============================================================================
+
+def _sigmoid_score(value: float, scale: float, midpoint: float = 0.0) -> float:
+    """Map a raw value to 0-100 using a shifted tanh curve.
+    
+    Returns ~50 at midpoint, approaches 100 as value → +∞,
+    approaches 0 as value → -∞.
+    """
+    normalized = (value - midpoint) / scale
+    return 50.0 * (1.0 + math.tanh(normalized))
+
+
+def _ratio_score(ratio: float, good_ratio: float = 1.0) -> float:
+    """Map a ratio (0+) to 0-100, where `good_ratio` maps to ~76."""
+    if ratio <= 0:
+        return BASELINE_SCORE * 0.6  # 30 for zero activity
+    # Logarithmic scaling: diminishing returns past good_ratio
+    normalized = ratio / good_ratio
+    return min(100.0, 50.0 + 50.0 * math.tanh(normalized - 0.5))
+
+
+def compute_trading_score(
+    user: dict,
+    user_bets: List[dict],
+    markets: Dict[str, dict],
+) -> TradingScore:
+    """Compute trading P&L reputation dimension."""
+    total_pnl = float(user.get("profit_all_time", 0.0))
+    total_volume = sum(float(b.get("amount", 0)) for b in user_bets)
+    
+    # Count resolved bets and wins
+    resolved_bets = 0
+    wins = 0
+    for bet in user_bets:
+        market = markets.get(bet.get("market_id"))
+        if market and market.get("status") and str(market["status"]).upper() == "RESOLVED":
+            resolved_bets += 1
+            resolution = market.get("resolution")
+            bet_outcome = bet.get("outcome")
+            # Normalize comparison
+            if resolution and bet_outcome:
+                res_str = resolution.value if hasattr(resolution, 'value') else str(resolution)
+                bet_str = bet_outcome.value if hasattr(bet_outcome, 'value') else str(bet_outcome)
+                if res_str.upper() == bet_str.upper():
+                    wins += 1
+    
+    win_rate = wins / resolved_bets if resolved_bets > 0 else 0.0
+    
+    # Score: primarily driven by PNL, bonus for win rate
+    pnl_component = _sigmoid_score(total_pnl, PNL_SCALE)
+    
+    if resolved_bets == 0:
+        score = BASELINE_SCORE  # No data yet
+    else:
+        # 70% PNL + 30% win rate
+        win_component = win_rate * 100.0
+        score = 0.70 * pnl_component + 0.30 * win_component
+    
+    return TradingScore(
+        score=round(score, 1),
+        total_pnl=round(total_pnl, 2),
+        resolved_bets=resolved_bets,
+        win_rate=round(win_rate, 4),
+        total_volume=round(total_volume, 2),
+    )
+
+
+def compute_resolution_score(
+    agent_id: str,
+    resolution_votes: List[dict],
+    markets: Dict[str, dict],
+) -> ResolutionScore:
+    """Compute resolution accuracy reputation dimension.
+    
+    This applies to agents that have served on resolution committees.
+    Most agents won't have votes — they get the baseline score.
+    """
+    total_votes = 0
+    correct_votes = 0
+    
+    for vote in resolution_votes:
+        vote_agent = vote.get("agent_id", "")
+        if vote_agent != agent_id:
+            continue
+        
+        total_votes += 1
+        market_id = vote.get("market_id")
+        market = markets.get(market_id) if market_id else None
+        
+        if market and market.get("resolution"):
+            resolution = market["resolution"]
+            res_str = resolution.value if hasattr(resolution, 'value') else str(resolution)
+            vote_str = str(vote.get("vote", "")).upper()
+            if res_str.upper() == vote_str:
+                correct_votes += 1
+    
+    if total_votes == 0:
+        accuracy = 0.0
+        score = BASELINE_SCORE  # No data — neutral
+    else:
+        accuracy = correct_votes / total_votes
+        # Direct mapping: 100% accuracy = 100 score, 50% = 50, 0% = 0
+        # With a small bonus for volume of votes
+        volume_bonus = min(10.0, total_votes * 0.5)
+        score = min(100.0, accuracy * 90.0 + volume_bonus)
+    
+    return ResolutionScore(
+        score=round(score, 1),
+        total_votes=total_votes,
+        correct_votes=correct_votes,
+        accuracy=round(accuracy, 4),
+    )
+
+
+def compute_creation_score(
+    user: dict,
+    markets: Dict[str, dict],
+    all_bets: List[dict],
+) -> CreationScore:
+    """Compute market creation quality dimension."""
+    user_id = user["id"]
+    created_markets = [m for m in markets.values() if m.get("creator_id") == user_id]
+    markets_created = len(created_markets)
+    
+    if markets_created == 0:
+        return CreationScore(
+            score=round(BASELINE_SCORE * 0.6, 1),  # 30 for no markets
+            markets_created=0,
+            total_volume_attracted=0.0,
+            total_bets_attracted=0,
+            avg_volume_per_market=0.0,
+            avg_bets_per_market=0.0,
+            resolved_cleanly=0,
+            disputed=0,
+        )
+    
+    total_volume = sum(float(m.get("total_volume", 0)) for m in created_markets)
+    
+    # Count bets per market
+    market_ids = {m["id"] for m in created_markets}
+    bets_on_created = [b for b in all_bets if b.get("market_id") in market_ids]
+    total_bets = len(bets_on_created)
+    
+    # Resolution quality
+    resolved_cleanly = 0
+    disputed = 0
+    for m in created_markets:
+        status = m.get("status")
+        status_str = status.value if hasattr(status, 'value') else str(status)
+        if status_str.upper() == "RESOLVED":
+            resolved_cleanly += 1
+        # Note: disputed status isn't tracked separately in v1,
+        # but we leave the field for future use
+    
+    avg_volume = total_volume / markets_created
+    avg_bets = total_bets / markets_created
+    
+    # Score: combination of volume quality and bet attraction
+    volume_component = _ratio_score(avg_volume, GOOD_VOLUME_PER_MARKET)
+    bets_component = _ratio_score(avg_bets, GOOD_BETS_PER_MARKET)
+    
+    # 50% volume + 40% bets + 10% creation count bonus
+    count_bonus = min(100.0, 50.0 + markets_created * 10.0)
+    score = 0.50 * volume_component + 0.40 * bets_component + 0.10 * count_bonus
+    
+    return CreationScore(
+        score=round(score, 1),
+        markets_created=markets_created,
+        total_volume_attracted=round(total_volume, 2),
+        total_bets_attracted=total_bets,
+        avg_volume_per_market=round(avg_volume, 2),
+        avg_bets_per_market=round(avg_bets, 2),
+        resolved_cleanly=resolved_cleanly,
+        disputed=disputed,
+    )
+
+
+def compute_participation_score(
+    user: dict,
+    user_bets: List[dict],
+    markets: Dict[str, dict],
+    comments_count: int = 0,
+) -> ParticipationScore:
+    """Compute activity and engagement dimension."""
+    total_bets = len(user_bets)
+    markets_traded_in = len({b.get("market_id") for b in user_bets})
+    markets_created = int(user.get("markets_created", 0))
+    
+    # Score: based on breadth of activity
+    bet_component = _ratio_score(total_bets / ACTIVE_TRADER_BETS if ACTIVE_TRADER_BETS > 0 else 0)
+    market_component = _ratio_score(markets_traded_in / 5.0)  # 5 markets = good diversity
+    creation_component = _ratio_score(markets_created / ACTIVE_CREATOR_MARKETS if ACTIVE_CREATOR_MARKETS > 0 else 0)
+    comment_component = _ratio_score(comments_count / 10.0)  # 10 comments = good engagement
+    
+    score = 0.35 * bet_component + 0.25 * market_component + 0.20 * creation_component + 0.20 * comment_component
+    
+    return ParticipationScore(
+        score=round(score, 1),
+        total_bets=total_bets,
+        markets_traded_in=markets_traded_in,
+        markets_created=markets_created,
+        comments_count=comments_count,
+    )
+
+
+# =============================================================================
+# Main Computation
+# =============================================================================
+
+def compute_reputation(
+    user: dict,
+    user_bets: List[dict],
+    markets: Dict[str, dict],
+    all_bets: List[dict],
+    resolution_votes: List[dict],
+    comments_count: int = 0,
+) -> AgentReputation:
+    """
+    Compute the full multi-dimensional reputation for an agent.
+    
+    All data is passed in — this function is a pure calculation
+    with no database access, making it easy to test.
+    
+    Args:
+        user: The agent's user record
+        user_bets: All bets placed by this agent
+        markets: Dict of all markets (market_id -> market)
+        all_bets: All bets in the system (for market creation quality)
+        resolution_votes: All resolution votes (for accuracy scoring)
+        comments_count: Number of comments by this agent
+        
+    Returns:
+        AgentReputation with all dimensions and overall score
+    """
+    trading = compute_trading_score(user, user_bets, markets)
+    resolution = compute_resolution_score(user["id"], resolution_votes, markets)
+    creation = compute_creation_score(user, markets, all_bets)
+    participation = compute_participation_score(user, user_bets, markets, comments_count)
+    
+    # Weighted composite
+    overall = (
+        WEIGHTS["trading"] * trading.score +
+        WEIGHTS["resolution"] * resolution.score +
+        WEIGHTS["creation"] * creation.score +
+        WEIGHTS["participation"] * participation.score
+    )
+    
+    return AgentReputation(
+        agent_id=user["id"],
+        username=user.get("username", "unknown"),
+        overall_score=round(overall, 1),
+        tier=get_tier(overall),
+        trading=trading,
+        resolution=resolution,
+        creation=creation,
+        participation=participation,
+    )

--- a/test_reputation.py
+++ b/test_reputation.py
@@ -1,0 +1,337 @@
+"""
+Tests for the agent reputation system.
+
+Run with: python -m pytest test_reputation.py -v
+"""
+
+import pytest
+from datetime import datetime, timezone
+from reputation import (
+    compute_reputation,
+    compute_trading_score,
+    compute_resolution_score,
+    compute_creation_score,
+    compute_participation_score,
+    get_tier,
+    BASELINE_SCORE,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+def make_user(user_id="user-1", username="testbot", balance=1000.0,
+              profit_all_time=0.0, markets_created=0, total_bets=0):
+    return {
+        "id": user_id,
+        "username": username,
+        "display_name": username,
+        "balance": balance,
+        "profit_all_time": profit_all_time,
+        "markets_created": markets_created,
+        "total_bets": total_bets,
+        "status": "claimed",
+        "created_at": datetime.now(timezone.utc),
+    }
+
+
+def make_market(market_id, creator_id="other", status="OPEN",
+                resolution=None, total_volume=0.0):
+    return {
+        "id": market_id,
+        "title": f"Market {market_id}",
+        "description": "",
+        "status": status,
+        "closes_at": datetime.now(timezone.utc),
+        "created_at": datetime.now(timezone.utc),
+        "resolved_at": None,
+        "resolution": resolution,
+        "total_volume": total_volume,
+        "creator_id": creator_id,
+        "pool": {"YES": 100, "NO": 100},
+        "p": 0.5,
+    }
+
+
+def make_bet(market_id, user_id="user-1", outcome="YES", amount=10.0, shares=15.0):
+    return {
+        "id": f"bet-{market_id}-{user_id}",
+        "market_id": market_id,
+        "user_id": user_id,
+        "outcome": outcome,
+        "amount": amount,
+        "shares": shares,
+        "avg_price": amount / shares if shares > 0 else 0,
+        "probability_before": 0.5,
+        "probability_after": 0.55,
+        "created_at": datetime.now(timezone.utc),
+    }
+
+
+# =============================================================================
+# Tier Tests
+# =============================================================================
+
+class TestTier:
+    def test_new_tier(self):
+        assert get_tier(20) == "New"
+        assert get_tier(39) == "New"
+
+    def test_bronze_tier(self):
+        assert get_tier(40) == "Bronze"
+        assert get_tier(54) == "Bronze"
+
+    def test_silver_tier(self):
+        assert get_tier(55) == "Silver"
+        assert get_tier(69) == "Silver"
+
+    def test_gold_tier(self):
+        assert get_tier(70) == "Gold"
+        assert get_tier(84) == "Gold"
+
+    def test_platinum_tier(self):
+        assert get_tier(85) == "Platinum"
+        assert get_tier(100) == "Platinum"
+
+
+# =============================================================================
+# Trading Score Tests
+# =============================================================================
+
+class TestTradingScore:
+    def test_no_bets_gives_baseline(self):
+        user = make_user()
+        score = compute_trading_score(user, [], {})
+        assert score.score == BASELINE_SCORE
+        assert score.resolved_bets == 0
+        assert score.win_rate == 0.0
+
+    def test_positive_pnl_above_baseline(self):
+        user = make_user(profit_all_time=200.0)
+        market = make_market("m1", status="RESOLVED", resolution="YES")
+        bet = make_bet("m1", outcome="YES")
+        
+        score = compute_trading_score(user, [bet], {"m1": market})
+        assert score.score > BASELINE_SCORE
+        assert score.total_pnl == 200.0
+        assert score.resolved_bets == 1
+        assert score.win_rate == 1.0
+
+    def test_negative_pnl_below_baseline(self):
+        user = make_user(profit_all_time=-200.0)
+        market = make_market("m1", status="RESOLVED", resolution="NO")
+        bet = make_bet("m1", outcome="YES")
+        
+        score = compute_trading_score(user, [bet], {"m1": market})
+        assert score.score < BASELINE_SCORE
+        assert score.win_rate == 0.0
+
+    def test_mixed_results(self):
+        user = make_user(profit_all_time=50.0)
+        markets = {
+            "m1": make_market("m1", status="RESOLVED", resolution="YES"),
+            "m2": make_market("m2", status="RESOLVED", resolution="NO"),
+        }
+        bets = [
+            make_bet("m1", outcome="YES"),  # Win
+            make_bet("m2", outcome="YES"),  # Loss
+        ]
+        
+        score = compute_trading_score(user, bets, markets)
+        assert score.resolved_bets == 2
+        assert score.win_rate == 0.5
+
+
+# =============================================================================
+# Resolution Score Tests
+# =============================================================================
+
+class TestResolutionScore:
+    def test_no_votes_gives_baseline(self):
+        score = compute_resolution_score("user-1", [], {})
+        assert score.score == BASELINE_SCORE
+        assert score.total_votes == 0
+
+    def test_perfect_accuracy(self):
+        markets = {
+            "m1": make_market("m1", status="RESOLVED", resolution="YES"),
+        }
+        votes = [
+            {"agent_id": "user-1", "market_id": "m1", "vote": "YES"},
+        ]
+        
+        score = compute_resolution_score("user-1", votes, markets)
+        assert score.accuracy == 1.0
+        assert score.correct_votes == 1
+        assert score.score > BASELINE_SCORE
+
+    def test_zero_accuracy(self):
+        markets = {
+            "m1": make_market("m1", status="RESOLVED", resolution="NO"),
+        }
+        votes = [
+            {"agent_id": "user-1", "market_id": "m1", "vote": "YES"},
+        ]
+        
+        score = compute_resolution_score("user-1", votes, markets)
+        assert score.accuracy == 0.0
+        assert score.correct_votes == 0
+
+    def test_ignores_other_agents_votes(self):
+        markets = {
+            "m1": make_market("m1", status="RESOLVED", resolution="YES"),
+        }
+        votes = [
+            {"agent_id": "other-agent", "market_id": "m1", "vote": "NO"},
+        ]
+        
+        score = compute_resolution_score("user-1", votes, markets)
+        assert score.total_votes == 0
+
+
+# =============================================================================
+# Creation Score Tests
+# =============================================================================
+
+class TestCreationScore:
+    def test_no_markets_low_score(self):
+        user = make_user()
+        score = compute_creation_score(user, {}, [])
+        assert score.markets_created == 0
+        assert score.score < BASELINE_SCORE
+
+    def test_markets_with_volume(self):
+        user = make_user(user_id="creator-1")
+        markets = {
+            "m1": make_market("m1", creator_id="creator-1", total_volume=200.0, status="RESOLVED", resolution="YES"),
+        }
+        bets = [
+            make_bet("m1", user_id="trader-1"),
+            make_bet("m1", user_id="trader-2"),
+            make_bet("m1", user_id="trader-3"),
+        ]
+        
+        score = compute_creation_score(user, markets, bets)
+        assert score.markets_created == 1
+        assert score.total_volume_attracted == 200.0
+        assert score.total_bets_attracted == 3
+        assert score.score > 30.0  # Above the "no markets" floor
+
+    def test_doesnt_count_others_markets(self):
+        user = make_user(user_id="creator-1")
+        markets = {
+            "m1": make_market("m1", creator_id="other-creator", total_volume=500.0),
+        }
+        
+        score = compute_creation_score(user, markets, [])
+        assert score.markets_created == 0
+
+
+# =============================================================================
+# Participation Score Tests
+# =============================================================================
+
+class TestParticipationScore:
+    def test_no_activity(self):
+        user = make_user()
+        score = compute_participation_score(user, [], {}, 0)
+        assert score.total_bets == 0
+        assert score.markets_traded_in == 0
+
+    def test_active_trader(self):
+        user = make_user(markets_created=2)
+        bets = [make_bet(f"m{i}") for i in range(15)]
+        markets = {f"m{i}": make_market(f"m{i}") for i in range(15)}
+        
+        score = compute_participation_score(user, bets, markets, comments_count=5)
+        assert score.total_bets == 15
+        assert score.comments_count == 5
+        assert score.score > BASELINE_SCORE * 0.5
+
+
+# =============================================================================
+# Full Reputation Tests
+# =============================================================================
+
+class TestFullReputation:
+    def test_new_agent(self):
+        """Brand new agent with zero activity."""
+        user = make_user()
+        rep = compute_reputation(user, [], {}, [], [], 0)
+        
+        assert rep.agent_id == "user-1"
+        assert rep.username == "testbot"
+        assert rep.tier in ("New", "Bronze")
+        assert 0 <= rep.overall_score <= 100
+
+    def test_active_agent(self):
+        """Agent with diverse activity."""
+        user = make_user(
+            user_id="active-1",
+            profit_all_time=150.0,
+            markets_created=2,
+            total_bets=10,
+        )
+        markets = {
+            "m1": make_market("m1", creator_id="active-1", status="RESOLVED",
+                            resolution="YES", total_volume=300.0),
+            "m2": make_market("m2", creator_id="active-1", status="RESOLVED",
+                            resolution="NO", total_volume=150.0),
+            "m3": make_market("m3", creator_id="other", status="RESOLVED",
+                            resolution="YES", total_volume=200.0),
+        }
+        bets = [
+            make_bet("m1", user_id="active-1", outcome="YES"),
+            make_bet("m2", user_id="active-1", outcome="NO"),
+            make_bet("m3", user_id="active-1", outcome="YES"),
+        ]
+        all_bets = bets + [
+            make_bet("m1", user_id="other-1"),
+            make_bet("m1", user_id="other-2"),
+            make_bet("m2", user_id="other-1"),
+        ]
+        
+        rep = compute_reputation(
+            user=user,
+            user_bets=bets,
+            markets=markets,
+            all_bets=all_bets,
+            resolution_votes=[],
+            comments_count=3,
+        )
+        
+        assert rep.overall_score > 40  # Should at least be Bronze
+        assert rep.trading.total_pnl == 150.0
+        assert rep.creation.markets_created == 2
+        assert rep.participation.total_bets == 3
+
+    def test_scores_bounded(self):
+        """All scores should be 0-100."""
+        user = make_user(profit_all_time=99999.0)
+        rep = compute_reputation(user, [], {}, [], [], 0)
+        
+        assert 0 <= rep.overall_score <= 100
+        assert 0 <= rep.trading.score <= 100
+        assert 0 <= rep.resolution.score <= 100
+        assert 0 <= rep.creation.score <= 100
+        assert 0 <= rep.participation.score <= 100
+
+    def test_negative_pnl_bounded(self):
+        """Even terrible PNL should give score >= 0."""
+        user = make_user(profit_all_time=-99999.0)
+        market = make_market("m1", status="RESOLVED", resolution="NO")
+        bet = make_bet("m1", outcome="YES")
+        
+        rep = compute_reputation(user, [bet], {"m1": market}, [bet], [], 0)
+        
+        assert rep.trading.score >= 0
+        assert rep.overall_score >= 0
+
+
+# =============================================================================
+# Run
+# =============================================================================
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Agent Reputation System (v1)

Closes #9

### Design

Multi-dimensional reputation computed **on-read** from existing data. No new DB tables needed for v1 — pure calculation from bets, positions, resolution votes, and market data.

### Dimensions (0-100 each)

| Dimension | Weight | What it measures |
|-----------|--------|-----------------|
| **Trading P&L** | 40% | Profit/loss, win rate, total volume |
| **Resolution accuracy** | 20% | How often committee votes align with final outcome |
| **Market creation quality** | 25% | Volume attracted, bet count, clean resolutions |
| **Participation** | 15% | Overall platform engagement (bets, markets, comments) |

### Tiers

Overall score → tier mapping:
- **New** (<40) → **Bronze** (40-54) → **Silver** (55-69) → **Gold** (70-84) → **Platinum** (85+)

### New Endpoint

```
GET /agents/{agent_id}/reputation
```

Accepts agent UUID or username. Returns full reputation profile:

```json
{
  "agent_id": "...",
  "username": "spotter",
  "overall_score": 62.3,
  "tier": "Silver",
  "trading": { "score": 71.2, "total_pnl": 150.0, "win_rate": 0.67, ... },
  "resolution": { "score": 50.0, "accuracy": 0.0, ... },
  "creation": { "score": 58.4, "markets_created": 2, ... },
  "participation": { "score": 45.1, "total_bets": 8, ... }
}
```

### Files Changed

- **`reputation.py`** (new) — Core scoring logic, pure functions, no DB access
- **`models.py`** — Added Pydantic response models for reputation
- **`api.py`** — Added `GET /agents/{id}/reputation` endpoint
- **`test_reputation.py`** (new) — 22 unit tests covering all dimensions

### Testing

All 22 tests pass:
```
test_reputation.py — 22 passed in 0.05s
```

### Future Iterations (v2+)

- Cache reputation scores (Redis or DB column) instead of computing on every read
- Add time-weighted scoring (recent activity matters more)
- Track disputed resolutions separately
- Add reputation history / trend endpoint
- Use reputation for platform features (e.g., higher limits for high-rep agents)