### PR TITLE
perf: add missing database indexes for common query patterns

### DIFF
--- a/api.py
+++ b/api.py
@@ -426,6 +426,14 @@ class Storage:
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_markets_status ON markets(status)")
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_users_api_key ON users(api_key_hash)")
                 
+                # Additional indexes for common query patterns (see #50)
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_positions_user ON positions(user_id)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_markets_creator ON markets(creator_id)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_comments_user ON comments(user_id)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_markets_closes_at ON markets(closes_at)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_users_status ON users(status)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_users_lower_username ON users(LOWER(username))")
+                
                 conn.commit()
                 print("Database tables initialized")
         finally:

--- a/migrations/004_add_missing_indexes.sql
+++ b/migrations/004_add_missing_indexes.sql
@@ -1,0 +1,25 @@
+-- Migration 004: Add missing indexes for common query patterns
+-- Issue: https://github.com/shirtlessfounder/moltmarkets-api/issues/50
+--
+-- These columns are used in WHERE clauses, JOINs, and ORDER BY but lack indexes,
+-- causing sequential scans as data grows.
+--
+-- Safe to run multiple times (IF NOT EXISTS).
+
+-- positions.user_id: used when fetching all positions for a user
+CREATE INDEX IF NOT EXISTS idx_positions_user ON positions(user_id);
+
+-- markets.creator_id: used in reputation scoring and leaderboard
+CREATE INDEX IF NOT EXISTS idx_markets_creator ON markets(creator_id);
+
+-- comments.user_id: used in reputation comment counting
+CREATE INDEX IF NOT EXISTS idx_comments_user ON comments(user_id);
+
+-- markets.closes_at: used for auto-transition (OPEN → RESOLVING)
+CREATE INDEX IF NOT EXISTS idx_markets_closes_at ON markets(closes_at);
+
+-- users.status: used in leaderboard filter (claimed agents only)
+CREATE INDEX IF NOT EXISTS idx_users_status ON users(status);
+
+-- users.LOWER(username): used in case-insensitive username lookups
+CREATE INDEX IF NOT EXISTS idx_users_lower_username ON users(LOWER(username));


### PR DESCRIPTION
## Summary
Adds 6 missing database indexes that cover frequently queried columns currently doing sequential scans.

## Changes
- Added indexes in `_init_db()` (new deployments)
- Added `migrations/004_add_missing_indexes.sql` (existing databases)

## Indexes Added
| Index | Column | Query Pattern |
|-------|--------|---------------|
| `idx_positions_user` | `positions.user_id` | User position lookups |
| `idx_markets_creator` | `markets.creator_id` | Reputation scoring, leaderboard |
| `idx_comments_user` | `comments.user_id` | Reputation comment counting |
| `idx_markets_closes_at` | `markets.closes_at` | OPEN→RESOLVING auto-transition |
| `idx_users_status` | `users.status` | Leaderboard (claimed-only filter) |
| `idx_users_lower_username` | `users.LOWER(username)` | Case-insensitive username lookups |

## Risk: Zero
All `CREATE INDEX IF NOT EXISTS` — idempotent, no schema changes, no data changes. Migration can be run on production immediately.

Closes #50