### PR TITLE
security: fix timing attack on admin secret + add rate limiting

### DIFF
--- a/api.py
+++ b/api.py
@@ -2402,14 +2402,22 @@ if not ADMIN_SECRET:
 
 
 @app.delete("/admin/users/{username}")
-async def admin_delete_user(username: str, x_admin_secret: str = Header(None)):
+async def admin_delete_user(username: str, request: Request, x_admin_secret: str = Header(None)):
     """
     Delete a user by username (admin only).
     Requires X-Admin-Secret header.
     """
     if not ADMIN_SECRET:
         raise HTTPException(status_code=503, detail="Admin endpoints disabled — ADMIN_SECRET not configured")
-    if x_admin_secret != ADMIN_SECRET:
+    
+    # Rate limit admin endpoints to mitigate brute-force attacks
+    client_ip = request.client.host if request.client else "unknown"
+    allowed, info = rate_limiter.check(f"admin:{client_ip}", max_requests=10, window_seconds=60)
+    if not allowed:
+        raise HTTPException(status_code=429, detail=f"Admin rate limit exceeded. {info['detail']}")
+    
+    # Use constant-time comparison to prevent timing attacks (see #55)
+    if not secrets.compare_digest(x_admin_secret or "", ADMIN_SECRET):
         raise HTTPException(status_code=403, detail="Invalid admin secret")
     
     user = db.get_user_by_username(username)
@@ -2423,14 +2431,22 @@ async def admin_delete_user(username: str, x_admin_secret: str = Header(None)):
 
 
 @app.post("/admin/users/{username}/regenerate-key")
-async def admin_regenerate_api_key(username: str, x_admin_secret: str = Header(None)):
+async def admin_regenerate_api_key(username: str, request: Request, x_admin_secret: str = Header(None)):
     """
     Regenerate API key for a user (admin only).
     Returns the new API key — save it, it won't be shown again!
     """
     if not ADMIN_SECRET:
         raise HTTPException(status_code=503, detail="Admin endpoints disabled — ADMIN_SECRET not configured")
-    if x_admin_secret != ADMIN_SECRET:
+    
+    # Rate limit admin endpoints to mitigate brute-force attacks
+    client_ip = request.client.host if request.client else "unknown"
+    allowed, info = rate_limiter.check(f"admin:{client_ip}", max_requests=10, window_seconds=60)
+    if not allowed:
+        raise HTTPException(status_code=429, detail=f"Admin rate limit exceeded. {info['detail']}")
+    
+    # Use constant-time comparison to prevent timing attacks (see #55)
+    if not secrets.compare_digest(x_admin_secret or "", ADMIN_SECRET):
         raise HTTPException(status_code=403, detail="Invalid admin secret")
     
     user = db.get_user_by_username(username)


### PR DESCRIPTION
## Summary
Fixes a timing attack vulnerability in admin endpoint authentication and adds rate limiting to prevent brute-force attacks.

## Changes

### 1. Constant-time secret comparison
**Before (vulnerable):**
```python
if x_admin_secret != ADMIN_SECRET:  # short-circuits on first byte difference
```

**After (secure):**
```python
if not secrets.compare_digest(x_admin_secret or '', ADMIN_SECRET):  # constant-time
```

### 2. Rate limiting on admin endpoints
Added 10 requests/minute per IP rate limit to both:
- `DELETE /admin/users/{username}`
- `POST /admin/users/{username}/regenerate-key`

## Risk: Low
- `secrets.compare_digest` is a stdlib function, same behavior but constant-time
- Rate limiting uses the existing `rate_limiter` singleton
- No new dependencies

Closes #55