### PR TITLE
devops: add CI pipeline with lint, test, and security audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run ruff (errors only, no style nitpicks)
+        run: ruff check . --select E,F,W --ignore E501,W291,W292,W293
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-cov
+      - name: Run tests
+        run: pytest -v --tb=short
+      - name: Run tests with coverage
+        run: pytest --cov=. --cov-report=term-missing --cov-fail-under=10
+        # Start with 10% threshold — increase as tests are added (see #52)
+
+  security:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install -r requirements.txt pip-audit
+      - name: Audit dependencies
+        run: pip-audit


### PR DESCRIPTION
## Summary
Adds a GitHub Actions CI pipeline that runs on every push to main and on all PRs.

## CI Jobs

### 1. Lint (`ruff check`)
Catches Python errors, undefined names, unused imports. Configured to skip style nitpicks (line length, trailing whitespace) to avoid noise on existing code.

### 2. Test (`pytest`)
Runs the existing test suite (`test_reputation.py`) with coverage reporting. Coverage threshold starts at 10% — should be increased as more tests are added (see #52).

### 3. Security (`pip-audit`)
Scans `requirements.txt` dependencies for known CVEs. Fails the build if any vulnerabilities are found.

## File Added
- `.github/workflows/ci.yml`

## Risk: Zero
This only adds a new workflow file — no changes to application code. CI runs are free for public repos.

Closes #51