### PR TITLE
feat: add fee breakdown and new_balance to BetResponse

### DIFF
--- a/api.py
+++ b/api.py
@@ -29,7 +29,7 @@ from psycopg2.extras import RealDictCursor
 
 from models import (
     MarketCreate, MarketResolve, MarketSummary, MarketDetail, MarketCreated,
-    BetRequest, BetResponse, SellRequest, SellResponse, Position, MarketPositions,
+    BetRequest, BetResponse, FeeBreakdown, SellRequest, SellResponse, Position, MarketPositions,
     UserProfile, UserMe, ErrorResponse, LeaderboardEntry,
     ProbabilityPoint, MarketHistory, BetHistoryItem,
     AgentRegister, AgentRegistered, AgentRegisteredWithClaim, AgentKeyReset,
@@ -1747,12 +1747,24 @@ async def place_bet(market_id: str, req: BetRequest, user: dict = Depends(requir
         prob_after=prob_after,
     )
     
+    # Fetch updated balance for the response
+    updated_user = db.get_user(user["id"])
+    new_balance = updated_user["balance"] if updated_user else user["balance"] - total_cost
+    
     return BetResponse(
         bet_id=bet["id"],
         market_id=bet["market_id"],
         user_id=bet["user_id"],
         outcome=bet["outcome"],
         amount=bet["amount"],
+        fee=trade_fee,
+        fee_breakdown=FeeBreakdown(
+            total_fee=trade_fee,
+            creator_fee=creator_fee,
+            platform_fee=trade_fee - creator_fee,
+        ),
+        total_cost=total_cost,
+        new_balance=round(new_balance, 8),
         shares=bet["shares"],
         avg_price=bet["avg_price"],
         probability_before=bet["probability_before"],

--- a/models.py
+++ b/models.py
@@ -135,13 +135,24 @@ class BetRequest(BaseModel):
     amount: float = Field(..., gt=0, le=500, description="Bet amount in ŧ (max 500)")
 
 
+class FeeBreakdown(BaseModel):
+    """Breakdown of trading fees for a transaction."""
+    total_fee: float
+    creator_fee: float  # Portion paid to market creator
+    platform_fee: float  # Portion burned / retained by platform
+
+
 class BetResponse(BaseModel):
     """Result of placing a bet. Amounts are in points (ŧ)."""
     bet_id: str
     market_id: str
     user_id: str
     outcome: Outcome
-    amount: float
+    amount: float  # Bet amount (before fees)
+    fee: float  # Total fee charged
+    fee_breakdown: FeeBreakdown  # Detailed fee split
+    total_cost: float  # amount + fee (total deducted from balance)
+    new_balance: float  # User's balance after this trade
     shares: float
     avg_price: float  # amount / shares
     probability_before: float


### PR DESCRIPTION
## Summary

Agents currently can't see fee details when placing bets — the 2% fee is silently deducted. This PR adds full fee transparency to `BetResponse`.

### Before
```json
{
  "bet_id": "...",
  "amount": 100.0,
  "shares": 18.18,
  "avg_price": 0.55
}
```
Agent's balance drops by 102ŧ but response only shows 100ŧ. 🤔

### After
```json
{
  "bet_id": "...",
  "amount": 100.0,
  "fee": 2.0,
  "fee_breakdown": {
    "total_fee": 2.0,
    "creator_fee": 1.0,
    "platform_fee": 1.0
  },
  "total_cost": 102.0,
  "new_balance": 898.0,
  "shares": 18.18,
  "avg_price": 0.55
}
```

### Changes

- **models.py**: Added `FeeBreakdown` model; added `fee`, `fee_breakdown`, `total_cost`, `new_balance` fields to `BetResponse`
- **api.py**: Updated `place_bet()` to populate new fields; fetches updated balance after trade

### Why

- Agents can reconcile balance after each trade without extra `/me` calls
- Fee transparency lets agents calculate true P&L
- `SellResponse` already had `fee_paid` — this brings buy-side to parity
- `new_balance` eliminates race conditions between trade and balance check

Closes #73