### PR TITLE
feat: add rate limit headers (X-RateLimit-*, Retry-After) to all rate-limited endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -15,12 +15,41 @@ from typing import Dict, List, Optional
 from contextlib import asynccontextmanager
 from urllib.parse import urlparse, unquote
 
-from fastapi import FastAPI, HTTPException, Depends, Header, Request
+from fastapi import FastAPI, HTTPException, Depends, Header, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 import httpx
 
 from cpmm import CpmmState, calculate_cpmm_purchase, calculate_cpmm_sale, get_cpmm_probability, Outcome as CpmmOutcome
 from rate_limiter import rate_limiter, MAX_REGISTRATIONS_PER_HOUR, MAX_BETS_PER_MINUTE, MAX_BET_AMOUNT, MAX_CHAT_MESSAGES_PER_MINUTE
+
+
+def set_rate_limit_headers(response: Response, info: dict) -> None:
+    """Inject standard rate-limit headers into a FastAPI Response.
+
+    Headers follow the draft IETF RateLimit header spec and the widely-adopted
+    X-RateLimit-* convention so agent HTTP clients can self-throttle.
+    """
+    response.headers["X-RateLimit-Limit"] = str(info.get("limit", ""))
+    response.headers["X-RateLimit-Remaining"] = str(info.get("remaining", ""))
+    response.headers["X-RateLimit-Reset"] = str(info.get("reset", ""))
+
+
+def raise_rate_limited(detail: str, info: dict) -> None:
+    """Raise a 429 HTTPException with Retry-After header guidance.
+
+    The ``info`` dict comes from ``rate_limiter.check()`` and contains the
+    ``retry_after`` value in seconds.
+    """
+    raise HTTPException(
+        status_code=429,
+        detail=detail,
+        headers={
+            "Retry-After": str(info.get("retry_after", 60)),
+            "X-RateLimit-Limit": str(info.get("limit", "")),
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": str(info.get("reset", "")),
+        },
+    )
 import secrets
 import hashlib
 import psycopg2
@@ -1652,11 +1681,17 @@ async def resolve_market(market_id: str, req: MarketResolve, user: dict = Depend
 # =============================================================================
 
 @app.post("/markets/{market_id}/bet", response_model=BetResponse)
-async def place_bet(market_id: str, req: BetRequest, user: dict = Depends(require_auth)):
+async def place_bet(market_id: str, req: BetRequest, response: Response, user: dict = Depends(require_auth)):
     """Place a bet on a market.
     
     Rate limited: max 30 bets per agent per minute.
     Max bet amount: 500ŧ per single bet.
+    
+    Rate limit headers are included in every response:
+    - `X-RateLimit-Limit`: Max requests in window
+    - `X-RateLimit-Remaining`: Remaining requests
+    - `X-RateLimit-Reset`: Unix timestamp when window resets
+    - `Retry-After` (on 429 only): Seconds to wait
     """
     # Require twitter verification before trading
     if user.get("status") != "claimed":
@@ -1679,10 +1714,12 @@ async def place_bet(market_id: str, req: BetRequest, user: dict = Depends(requir
         window_seconds=60,
     )
     if not allowed:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Betting rate limit exceeded ({MAX_BETS_PER_MINUTE}/minute). {info['detail']}",
+        raise_rate_limited(
+            f"Betting rate limit exceeded ({MAX_BETS_PER_MINUTE}/minute). {info['detail']}",
+            info,
         )
+    # Inject rate limit headers on successful responses too
+    set_rate_limit_headers(response, info)
 
     market = db.get_market(market_id)
     if not market:
@@ -2314,7 +2351,7 @@ async def get_agent_reputation(agent_id: str):
 # =============================================================================
 
 @app.post("/agents/register", response_model=AgentRegisteredWithClaim)
-async def register_agent(req: AgentRegister, request: Request):
+async def register_agent(req: AgentRegister, request: Request, response: Response):
     """
     Register a new agent and get an API key.
     
@@ -2333,10 +2370,11 @@ async def register_agent(req: AgentRegister, request: Request):
         window_seconds=3600,
     )
     if not allowed:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Registration rate limit exceeded ({MAX_REGISTRATIONS_PER_HOUR}/hour per IP). {info['detail']}",
+        raise_rate_limited(
+            f"Registration rate limit exceeded ({MAX_REGISTRATIONS_PER_HOUR}/hour per IP). {info['detail']}",
+            info,
         )
+    set_rate_limit_headers(response, info)
 
     # Normalize username to lowercase (case-insensitive uniqueness)
     username = req.username.lower()
@@ -2552,7 +2590,7 @@ async def claim_agent(req: ClaimRequest):
 # =============================================================================
 
 @app.post("/humans/register", response_model=HumanRegistered)
-async def register_human(req: HumanRegister, request: Request):
+async def register_human(req: HumanRegister, request: Request, response: Response):
     """
     Register a human user for chat.
     
@@ -2570,10 +2608,11 @@ async def register_human(req: HumanRegister, request: Request):
         window_seconds=3600,
     )
     if not allowed:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Registration rate limit exceeded ({MAX_REGISTRATIONS_PER_HOUR}/hour per IP). {info['detail']}",
+        raise_rate_limited(
+            f"Registration rate limit exceeded ({MAX_REGISTRATIONS_PER_HOUR}/hour per IP). {info['detail']}",
+            info,
         )
+    set_rate_limit_headers(response, info)
 
     # Normalize username to lowercase
     username = req.username.lower()
@@ -2669,7 +2708,7 @@ async def get_leaderboard():
 # =============================================================================
 
 @app.post("/chat", response_model=ChatMessage)
-async def send_chat_message(req: ChatMessageCreate, channel: str = "agents", user: dict = Depends(require_auth)):
+async def send_chat_message(req: ChatMessageCreate, response: Response, channel: str = "agents", user: dict = Depends(require_auth)):
     """
     Send a chat message.
     
@@ -2698,10 +2737,11 @@ async def send_chat_message(req: ChatMessageCreate, channel: str = "agents", use
         window_seconds=60,
     )
     if not allowed:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Chat rate limit exceeded ({MAX_CHAT_MESSAGES_PER_MINUTE}/minute). {info['detail']}",
+        raise_rate_limited(
+            f"Chat rate limit exceeded ({MAX_CHAT_MESSAGES_PER_MINUTE}/minute). {info['detail']}",
+            info,
         )
+    set_rate_limit_headers(response, info)
     
     message = db.create_chat_message(
         user_id=user["id"],

--- a/rate_limiter.py
+++ b/rate_limiter.py
@@ -55,7 +55,8 @@ class RateLimiter:
         Returns:
             (allowed, info)
             - allowed: True if under the limit, False if rate-limited.
-            - info: dict with "remaining", "reset_in", and "detail" (human-readable).
+            - info: dict with "limit", "remaining", "reset_in", "retry_after",
+              and "detail" (human-readable).
         """
         now = time.time()
         cutoff = now - window_seconds
@@ -73,10 +74,14 @@ class RateLimiter:
                 # Find when the oldest entry expires
                 oldest = min(timestamps) if timestamps else now
                 reset_in = round(oldest + window_seconds - now, 1)
+                retry_after = max(1, int(reset_in))
                 return False, {
+                    "limit": max_requests,
                     "remaining": 0,
+                    "reset": int(now + reset_in),
                     "reset_in": max(0, reset_in),
-                    "detail": f"Rate limit exceeded. Try again in {max(1, int(reset_in))}s.",
+                    "retry_after": retry_after,
+                    "detail": f"Rate limit exceeded. Try again in {retry_after}s.",
                 }
 
             # Allow — record this request
@@ -88,8 +93,11 @@ class RateLimiter:
                 self._cleanup(now)
 
             return True, {
+                "limit": max_requests,
                 "remaining": remaining - 1,
+                "reset": int(now + window_seconds),
                 "reset_in": 0,
+                "retry_after": 0,
                 "detail": "",
             }
 


### PR DESCRIPTION
## Summary

Agents currently have **zero visibility** into their rate limit quota until they hit a 429. This PR adds standard rate limit headers to every response on rate-limited endpoints.

### Response headers (all rate-limited endpoints)

```
HTTP/1.1 200 OK
X-RateLimit-Limit: 30
X-RateLimit-Remaining: 27
X-RateLimit-Reset: 1706745600
```

### 429 responses now include

```
HTTP/1.1 429 Too Many Requests
Retry-After: 42
X-RateLimit-Limit: 30
X-RateLimit-Remaining: 0
X-RateLimit-Reset: 1706745642
```

### Updated endpoints

| Endpoint | Limit | Window |
|----------|-------|--------|
| `POST /markets/{id}/bet` | 30 | 1 min |
| `POST /agents/register` | 5 | 1 hour |
| `POST /humans/register` | 5 | 1 hour |
| `POST /chat` | 10 | 1 min |

### Changes

- **rate_limiter.py**: Extended `check()` return dict with `limit`, `reset` (unix ts), `retry_after` fields
- **api.py**: Added `set_rate_limit_headers()` and `raise_rate_limited()` helpers; updated all rate-limited endpoints to inject headers on both success and 429

### Agent benefit

```python
# Before: agent has to guess when to retry
response = client.post("/markets/abc/bet", ...)
if response.status_code == 429:
    time.sleep(60)  # ¯\_(ツ)_/¯

# After: agent can self-throttle proactively
remaining = int(response.headers["X-RateLimit-Remaining"])
if remaining < 5:
    time.sleep(2)  # slow down preemptively
if response.status_code == 429:
    time.sleep(int(response.headers["Retry-After"]))  # exact wait
```

Closes #58