### PR TITLE
fix: restrict CORS origins, methods, and headers

### DIFF
--- a/api.py
+++ b/api.py
@@ -1695,22 +1695,33 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS: restrict to known origins. Override via CORS_ORIGINS env var (comma-separated).
+# CORS configuration — restrict origins, methods, and headers.
+# In DEBUG mode, allow all origins for local development.
+# Override origins via CORS_ORIGINS env var (comma-separated).
+_debug = os.getenv("DEBUG", "").lower() in ("1", "true", "yes")
+
 _default_origins = [
     "https://moltmarkets.com",
-    "https://www.moltmarkets.com",
     "http://localhost:3000",
-    "http://localhost:5173",
 ]
 _cors_origins = os.getenv("CORS_ORIGINS")
-ALLOWED_ORIGINS = [o.strip() for o in _cors_origins.split(",") if o.strip()] if _cors_origins else _default_origins
+ALLOWED_ORIGINS = (
+    ["*"]
+    if _debug
+    else [o.strip() for o in _cors_origins.split(",") if o.strip()]
+    if _cors_origins
+    else _default_origins
+)
+
+_allowed_methods = ["GET", "POST", "OPTIONS"]
+_allowed_headers = ["Authorization", "Content-Type"]
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_credentials=not _debug,  # credentials incompatible with wildcard origins
+    allow_methods=["*"] if _debug else _allowed_methods,
+    allow_headers=["*"] if _debug else _allowed_headers,
 )
 
 


### PR DESCRIPTION
## Summary

Closes #69 — CORS was overly permissive (`allow_methods=["*"]`, `allow_headers=["*"]`).

## Changes

| Setting | Before | After (production) |
|---------|--------|---------------------|
| Origins | 4 hardcoded + env override | `https://moltmarkets.com`, `http://localhost:3000` + env override |
| Methods | `["*"]` | `GET, POST, OPTIONS` |
| Headers | `["*"]` | `Authorization, Content-Type` |
| Credentials | Always `True` | `True` in prod, `False` in debug (wildcard compat) |

## Environment Variables

- **`CORS_ORIGINS`** — comma-separated list of allowed origins (overrides defaults)
- **`DEBUG`** — set to `1`/`true`/`yes` for permissive CORS in development (all origins, methods, headers)

## Testing

Verified all three code paths (production defaults, DEBUG mode, custom CORS_ORIGINS) produce correct allow-lists.