### PR TITLE
fix: resolve dependency audit CVEs (fastapi + pip upgrade)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: pip install -r requirements.txt pip-audit
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt pip-audit
       - name: Audit dependencies
         run: pip-audit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.115.0
+fastapi==0.128.0
 uvicorn==0.30.0
 pydantic==2.9.0
 python-dotenv==1.0.0


### PR DESCRIPTION
## Problem
The CI dependency audit (`pip-audit`) fails on **every PR** because of pre-existing vulnerabilities on main:

- **CVE-2024-47874** (starlette <0.40.0) — multipart DoS
- **CVE-2025-54121** (starlette <0.47.2) — header injection
- **CVE-2025-62727** (starlette <0.49.1) — path traversal
- **CVE-2025-8869** (pip <25.3) — code execution via malicious index

## Fix
- Upgrade `fastapi` 0.115.0 → 0.128.0 (pulls in starlette ≥0.49.1)
- Add `pip install --upgrade pip` before audit step in CI
- `pip-audit` now passes clean (0 vulnerabilities)

## Testing
Ran `pip-audit` locally — zero findings after these changes.