### PR TITLE
perf: replace full-table property accessors with targeted queries

### DIFF
--- a/api.py
+++ b/api.py
@@ -835,9 +835,47 @@ class Storage:
         finally:
             self._put_conn(conn)
     
+    def count_users(self) -> int:
+        """Count total users without loading all rows.
+
+        O(1) via COUNT(*) instead of O(N) full-table load.
+        Replaces ``len(db.users)`` in hot paths (health, startup).
+
+        See: https://github.com/shirtlessfounder/moltmarkets-api/issues/54
+        """
+        if self._use_memory:
+            return len(self._users)
+
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) AS cnt FROM users")
+                return cur.fetchone()["cnt"]
+        finally:
+            self._put_conn(conn)
+
     @property
     def users(self) -> Dict[str, dict]:
-        """Get all users (for leaderboard etc.)."""
+        """Get all users as dict.
+
+        .. deprecated::
+            Loads the **entire** users table into memory — O(N) on every call.
+            Use targeted methods instead:
+            - ``count_users()`` for counts
+            - ``get_user(id)`` for single lookups
+            - ``get_user_by_username(name)`` for name lookups
+            - ``get_leaderboard_data()`` for leaderboard
+
+        See: https://github.com/shirtlessfounder/moltmarkets-api/issues/54
+        """
+        import warnings
+        warnings.warn(
+            "db.users loads the entire users table into memory. "
+            "Use count_users(), get_user(), or get_leaderboard_data() instead. "
+            "See #54: https://github.com/shirtlessfounder/moltmarkets-api/issues/54",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._use_memory:
             return self._users
         
@@ -912,9 +950,123 @@ class Storage:
         finally:
             self._put_conn(conn)
     
+    def count_markets(self) -> int:
+        """Count total markets without loading all rows.
+
+        O(1) via COUNT(*) instead of O(N) full-table load.
+        Replaces ``len(db.markets)`` / ``len(db.list_markets())`` in hot paths.
+
+        See: https://github.com/shirtlessfounder/moltmarkets-api/issues/54
+        """
+        if self._use_memory:
+            return len(self._markets)
+
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) AS cnt FROM markets")
+                return cur.fetchone()["cnt"]
+        finally:
+            self._put_conn(conn)
+
+    def get_markets_by_ids(self, market_ids: set) -> Dict[str, dict]:
+        """Get specific markets by their IDs in a single query.
+
+        Returns a dict of {market_id: market_dict} for only the requested IDs.
+        O(K) where K = len(market_ids), instead of O(N) for the full table.
+
+        See: https://github.com/shirtlessfounder/moltmarkets-api/issues/54
+        """
+        if not market_ids:
+            return {}
+
+        if self._use_memory:
+            return {mid: self._markets[mid] for mid in market_ids if mid in self._markets}
+
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM markets WHERE id = ANY(%s)",
+                    (list(market_ids),),
+                )
+                rows = cur.fetchall()
+                return {row["id"]: self._row_to_market(row) for row in rows}
+        finally:
+            self._put_conn(conn)
+
+    def get_markets_by_creator(self, creator_id: str) -> List[dict]:
+        """Get all markets created by a specific user.
+
+        Uses idx_markets_creator index for O(1) lookup.
+
+        See: https://github.com/shirtlessfounder/moltmarkets-api/issues/54
+        """
+        if self._use_memory:
+            return [m for m in self._markets.values() if m.get("creator_id") == creator_id]
+
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM markets WHERE creator_id = %s ORDER BY created_at DESC",
+                    (creator_id,),
+                )
+                rows = cur.fetchall()
+                return [self._row_to_market(row) for row in rows]
+        finally:
+            self._put_conn(conn)
+
+    def get_bets_on_markets(self, market_ids: set) -> List[dict]:
+        """Get all bets placed on specific markets.
+
+        Used by reputation creation-score to count bets on a user's
+        created markets without loading the entire bets table.
+
+        See: https://github.com/shirtlessfounder/moltmarkets-api/issues/54
+        """
+        if not market_ids:
+            return []
+
+        if self._use_memory:
+            return [b for b in self._bets.values() if b.get("market_id") in market_ids]
+
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM bets WHERE market_id = ANY(%s) ORDER BY created_at",
+                    (list(market_ids),),
+                )
+                rows = cur.fetchall()
+                return [self._row_to_bet(row) for row in rows]
+        finally:
+            self._put_conn(conn)
+
     @property
     def markets(self) -> Dict[str, dict]:
-        """Get all markets as dict."""
+        """Get all markets as dict.
+
+        .. deprecated::
+            Loads the **entire** markets table into memory — O(N) on every call.
+            Use targeted methods instead:
+            - ``count_markets()`` for counts
+            - ``get_market(id)`` for single lookups
+            - ``list_markets()`` for ordered listing
+            - ``get_markets_by_ids(ids)`` for batch lookups
+            - ``get_markets_by_creator(uid)`` for creator filtering
+
+        See: https://github.com/shirtlessfounder/moltmarkets-api/issues/54
+        """
+        import warnings
+        warnings.warn(
+            "db.markets loads the entire markets table into memory. "
+            "Use count_markets(), get_market(), get_markets_by_ids(), or "
+            "get_markets_by_creator() instead. "
+            "See #54: https://github.com/shirtlessfounder/moltmarkets-api/issues/54",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._use_memory:
             return self._markets
         
@@ -1127,7 +1279,26 @@ class Storage:
     
     @property
     def bets(self) -> Dict[str, dict]:
-        """Get all bets as dict."""
+        """Get all bets as dict.
+
+        .. deprecated::
+            Loads the **entire** bets table into memory — O(N) on every call.
+            Use targeted methods instead:
+            - ``get_bets_for_market(market_id)`` for market bets
+            - ``get_bets_for_user(user_id)`` for user bets
+            - ``get_bets_on_markets(market_ids)`` for batch market bets
+
+        See: https://github.com/shirtlessfounder/moltmarkets-api/issues/54
+        """
+        import warnings
+        warnings.warn(
+            "db.bets loads the entire bets table into memory. "
+            "Use get_bets_for_market(), get_bets_for_user(), or "
+            "get_bets_on_markets() instead. "
+            "See #54: https://github.com/shirtlessfounder/moltmarkets-api/issues/54",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._use_memory:
             return self._bets
         
@@ -1679,8 +1850,8 @@ async def lifespan(app: FastAPI):
     # Startup: seed read-only demo user for unauthenticated access (zero balance)
     if not db.get_user("demo-user"):
         db.create_user("demo-user", "demo_user", balance=0.0)
-    market_count = len(db.list_markets())
-    user_count = len(db.users)
+    market_count = db.count_markets()
+    user_count = db.count_users()
     print(f"MoltMarkets API started with {market_count} markets, {user_count} users")
     yield
     # Shutdown: close the connection pool cleanly
@@ -2752,20 +2923,38 @@ async def get_agent_reputation(agent_id: str):
     if not user:
         raise HTTPException(status_code=404, detail="Agent not found")
     
-    # Gather all data needed for reputation calculation
-    # Optimized: batch queries instead of per-market N+1 loops
+    # Gather all data needed for reputation calculation.
+    # Optimized (#54): targeted queries instead of full-table loads.
+    # Previously: db.markets (ALL markets) + db.bets (ALL bets) → O(N) each.
+    # Now: fetch only the markets/bets relevant to this user → O(K) where K << N.
     user_bets = db.get_bets_for_user(user["id"])
-    markets = db.markets
-    all_bets_dict = db.bets
-    all_bets = list(all_bets_dict.values())
-    
-    # Single batch queries for resolution votes + comment count
-    # (was N+1: looped ALL markets calling get_resolution_votes + get_market_comments each)
+
+    # 1. Collect the market IDs we actually need:
+    #    - Markets the user bet on (for trading score)
+    #    - Markets created by the user (for creation score)
+    bet_market_ids = {b["market_id"] for b in user_bets}
+    user_created_markets = db.get_markets_by_creator(user["id"])
+    created_market_ids = {m["id"] for m in user_created_markets}
+
+    # 2. Batch-fetch resolution votes + comment count
     rep_data = db.get_reputation_data(user["id"])
     all_resolution_votes = rep_data["resolution_votes"]
     comments_count = rep_data["comments_count"]
-    
-    # Compute reputation
+
+    # Include market IDs from this user's resolution votes
+    vote_market_ids = {
+        v.get("market_id") for v in all_resolution_votes
+        if v.get("agent_id") == user["id"] and v.get("market_id")
+    }
+
+    # 3. Fetch only the markets we need (union of all relevant IDs)
+    all_needed_ids = bet_market_ids | created_market_ids | vote_market_ids
+    markets = db.get_markets_by_ids(all_needed_ids)
+
+    # 4. Fetch only bets on user's created markets (for creation score)
+    all_bets = db.get_bets_on_markets(created_market_ids) if created_market_ids else []
+
+    # Compute reputation (pure function — no DB access)
     rep = compute_reputation(
         user=user,
         user_bets=user_bets,
@@ -3470,8 +3659,8 @@ async def health():
             },
         )
 
-    market_count = len(db.list_markets())
-    user_count = len(db.users)
+    market_count = db.count_markets()
+    user_count = db.count_users()
     return {
         "status": "ok",
         "db": "ok",

--- a/test_lazy_load.py
+++ b/test_lazy_load.py
@@ -1,0 +1,216 @@
+"""
+Tests for issue #54: Targeted query methods replace full-table property accessors.
+
+Validates that:
+1. New count methods work correctly (count_users, count_markets)
+2. New targeted query methods return correct subsets (get_markets_by_ids, etc.)
+3. Deprecated property accessors still work but emit warnings
+4. Hot paths (health, reputation) no longer trigger full-table loads
+
+See: https://github.com/shirtlessfounder/moltmarkets-api/issues/54
+"""
+
+import warnings
+import uuid
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+# Force in-memory storage (no DATABASE_URL)
+import os
+os.environ.pop("DATABASE_URL", None)
+
+from api import Storage, Outcome, MarketStatus
+
+
+@pytest.fixture
+def db():
+    """Fresh in-memory storage instance for each test."""
+    return Storage()
+
+
+@pytest.fixture
+def populated_db(db):
+    """Storage pre-populated with test data for query method tests."""
+    # Create users
+    db.create_user("user-1", "alice", balance=1000.0)
+    db.create_user("user-2", "bob", balance=1000.0)
+    db.create_user("user-3", "charlie", balance=1000.0)
+
+    # Create markets
+    closes = datetime.now(timezone.utc) + timedelta(hours=1)
+    db.create_market("market-1", "user-1", "Will it rain?", "desc", closes, 100.0)
+    db.create_market("market-2", "user-1", "Will it snow?", "desc", closes, 100.0)
+    db.create_market("market-3", "user-2", "Will it hail?", "desc", closes, 100.0)
+
+    # Create bets
+    db.create_bet("bet-1", "market-1", "user-2", Outcome.YES, 50.0, 60.0, 0.5, 0.6)
+    db.create_bet("bet-2", "market-1", "user-3", Outcome.NO, 30.0, 35.0, 0.6, 0.55)
+    db.create_bet("bet-3", "market-2", "user-2", Outcome.YES, 20.0, 22.0, 0.5, 0.55)
+    db.create_bet("bet-4", "market-3", "user-1", Outcome.NO, 40.0, 45.0, 0.5, 0.45)
+
+    return db
+
+
+# ========== Count Methods ==========
+
+class TestCountMethods:
+    def test_count_users_empty(self, db):
+        assert db.count_users() == 0
+
+    def test_count_users_populated(self, populated_db):
+        assert populated_db.count_users() == 3
+
+    def test_count_markets_empty(self, db):
+        assert db.count_markets() == 0
+
+    def test_count_markets_populated(self, populated_db):
+        assert populated_db.count_markets() == 3
+
+    def test_count_users_after_create(self, db):
+        assert db.count_users() == 0
+        db.create_user("u1", "user1")
+        assert db.count_users() == 1
+        db.create_user("u2", "user2")
+        assert db.count_users() == 2
+
+
+# ========== Targeted Query Methods ==========
+
+class TestGetMarketsByIds:
+    def test_empty_ids_returns_empty(self, populated_db):
+        result = populated_db.get_markets_by_ids(set())
+        assert result == {}
+
+    def test_single_id(self, populated_db):
+        result = populated_db.get_markets_by_ids({"market-1"})
+        assert len(result) == 1
+        assert "market-1" in result
+        assert result["market-1"]["title"] == "Will it rain?"
+
+    def test_multiple_ids(self, populated_db):
+        result = populated_db.get_markets_by_ids({"market-1", "market-3"})
+        assert len(result) == 2
+        assert "market-1" in result
+        assert "market-3" in result
+
+    def test_nonexistent_ids_ignored(self, populated_db):
+        result = populated_db.get_markets_by_ids({"market-1", "nonexistent"})
+        assert len(result) == 1
+        assert "market-1" in result
+
+
+class TestGetMarketsByCreator:
+    def test_creator_with_markets(self, populated_db):
+        result = populated_db.get_markets_by_creator("user-1")
+        assert len(result) == 2
+        titles = {m["title"] for m in result}
+        assert titles == {"Will it rain?", "Will it snow?"}
+
+    def test_creator_with_one_market(self, populated_db):
+        result = populated_db.get_markets_by_creator("user-2")
+        assert len(result) == 1
+        assert result[0]["title"] == "Will it hail?"
+
+    def test_creator_no_markets(self, populated_db):
+        result = populated_db.get_markets_by_creator("user-3")
+        assert len(result) == 0
+
+
+class TestGetBetsOnMarkets:
+    def test_empty_ids_returns_empty(self, populated_db):
+        result = populated_db.get_bets_on_markets(set())
+        assert result == []
+
+    def test_single_market(self, populated_db):
+        result = populated_db.get_bets_on_markets({"market-1"})
+        assert len(result) == 2  # bet-1 and bet-2
+        user_ids = {b["user_id"] for b in result}
+        assert user_ids == {"user-2", "user-3"}
+
+    def test_multiple_markets(self, populated_db):
+        result = populated_db.get_bets_on_markets({"market-1", "market-2"})
+        assert len(result) == 3  # bet-1, bet-2, bet-3
+
+    def test_market_with_no_bets(self, db):
+        db.create_user("u1", "user1")
+        closes = datetime.now(timezone.utc) + timedelta(hours=1)
+        db.create_market("m1", "u1", "Empty market", "desc", closes, 100.0)
+        result = db.get_bets_on_markets({"m1"})
+        assert result == []
+
+
+# ========== Deprecation Warnings ==========
+
+class TestDeprecationWarnings:
+    def test_users_property_warns(self, populated_db):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = populated_db.users
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "#54" in str(w[0].message)
+            assert "count_users" in str(w[0].message)
+
+    def test_markets_property_warns(self, populated_db):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = populated_db.markets
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "#54" in str(w[0].message)
+
+    def test_bets_property_warns(self, populated_db):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = populated_db.bets
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "#54" in str(w[0].message)
+
+    def test_users_property_still_returns_data(self, populated_db):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            users = populated_db.users
+            assert len(users) == 3
+            assert "user-1" in users
+
+    def test_markets_property_still_returns_data(self, populated_db):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            markets = populated_db.markets
+            assert len(markets) == 3
+
+    def test_bets_property_still_returns_data(self, populated_db):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            bets = populated_db.bets
+            assert len(bets) == 4
+
+
+# ========== Consistency Checks ==========
+
+class TestConsistency:
+    """Verify new methods return same data as deprecated properties."""
+
+    def test_count_matches_property_len(self, populated_db):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert populated_db.count_users() == len(populated_db.users)
+            assert populated_db.count_markets() == len(populated_db.markets)
+
+    def test_get_markets_by_ids_all_matches_property(self, populated_db):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            all_via_prop = populated_db.markets
+            all_ids = set(all_via_prop.keys())
+            all_via_method = populated_db.get_markets_by_ids(all_ids)
+            assert set(all_via_method.keys()) == set(all_via_prop.keys())
+
+    def test_bets_on_all_markets_matches_property(self, populated_db):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            all_bets_prop = populated_db.bets
+            all_market_ids = set(populated_db.markets.keys())
+            all_bets_method = populated_db.get_bets_on_markets(all_market_ids)
+            assert len(all_bets_method) == len(all_bets_prop)


### PR DESCRIPTION
## Fixes #54 — Property accessors load entire tables

### Problem
`db.users`, `db.markets`, `db.bets` are property accessors that load the **ENTIRE table** into memory every time they're accessed. This is O(N) on every single request — the biggest perf bottleneck in the system.

**Before**: Every `/health` call loaded all users. Every `/reputation` call loaded all markets AND all bets.

### Changes

#### 1. New targeted query methods (O(1) or O(K) where K << N)
| Method | Replaces | Complexity |
|--------|----------|------------|
| `count_users()` | `len(db.users)` | O(1) via COUNT(*) |
| `count_markets()` | `len(db.markets)` | O(1) via COUNT(*) |
| `get_markets_by_ids(ids)` | `db.markets` + filter | O(K) indexed |
| `get_markets_by_creator(uid)` | `db.markets` + filter | O(K) indexed |
| `get_bets_on_markets(ids)` | `db.bets` + filter | O(K) indexed |

#### 2. Hot path updates
- **`/health`**: `len(db.users)` → `db.count_users()` — was O(N), now O(1)
- **`lifespan`**: same fix for startup logging
- **`/agents/{id}/reputation`**: was loading ALL markets + ALL bets (two full table scans). Now fetches only the markets/bets relevant to the specific user being queried.

#### 3. Backward compatibility preserved
- Property accessors still work — they now emit `DeprecationWarning` with migration guidance
- No breaking changes to any public API endpoint
- All existing tests pass unchanged

#### 4. Indexes
Already in place from #50: `idx_markets_creator`, `idx_bets_market`, `idx_bets_user`, etc.

### Performance impact
| Endpoint | Before | After |
|----------|--------|-------|
| `/health` | O(N) — full users table | O(1) — SQL COUNT |
| `/reputation` | O(N+M) — all markets + all bets | O(K) — user's data only |

With 1000 users and 10000 bets, reputation was loading ~11,000 rows per call. Now loads ~50 (typical user's relevant data).

### Tests
- ✅ 25 new tests covering counts, targeted queries, deprecation warnings, backward compat, and consistency
- ✅ All 22 existing reputation tests pass