### PR TITLE
feat: multi-resolver dispute system (#8)

### DIFF
--- a/api.py
+++ b/api.py
@@ -43,6 +43,8 @@ from models import (
     TradingScoreResponse, ResolutionScoreResponse,
     CreationScoreResponse, ParticipationScoreResponse,
     PortfolioPosition, PortfolioSummary, PortfolioResponse, UserBetHistoryItem,
+    DisputeCreate, DisputeVoteRequest, DisputeVoteResponse,
+    DisputeDetail, DisputeListResponse, DisputeStatus,
 )
 from rate_limiter import rate_limiter, MAX_REGISTRATIONS_PER_HOUR, MAX_BETS_PER_MINUTE, MAX_BET_AMOUNT, MAX_CHAT_MESSAGES_PER_MINUTE
 from reputation import compute_reputation
@@ -97,6 +99,9 @@ VERIFICATION_WORDS = [
 TRADE_FEE_RATE = 0.02  # 2% total fee
 CREATOR_FEE_SHARE = 0.5  # 50% of fee goes to market creator (1%)
 # Remaining 50% (1%) is burned (not allocated to anyone)
+
+DISPUTE_WINDOW_HOURS = 24              # Hours after resolution that disputes can be filed
+DISPUTE_VOTER_COUNT = 5                # Top N traders (by volume) eligible to vote on disputes
 
 MARKET_CREATION_COST = 100             # Cost in ŧ to create a market (funds the initial liquidity pool)
 CABAL_USERNAMES = {'bicep', 'spotter', 'crabby'}  # Cabal members get reduced cooldown
@@ -483,6 +488,40 @@ class Storage:
                     END $$;
                 """)
                 
+                # Dispute system tables (issue #8)
+                cur.execute("""
+                    DO $$
+                    BEGIN
+                        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='markets' AND column_name='dispute_window_ends') THEN
+                            ALTER TABLE markets ADD COLUMN dispute_window_ends TIMESTAMP WITH TIME ZONE;
+                        END IF;
+                    END $$;
+                """)
+                
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS disputes (
+                        id VARCHAR(255) PRIMARY KEY,
+                        market_id VARCHAR(255) NOT NULL REFERENCES markets(id),
+                        disputor_id VARCHAR(255) NOT NULL REFERENCES users(id),
+                        reason TEXT NOT NULL,
+                        status VARCHAR(50) NOT NULL DEFAULT 'OPEN',
+                        original_resolution VARCHAR(10) NOT NULL,
+                        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+                        resolved_at TIMESTAMP WITH TIME ZONE
+                    )
+                """)
+                
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS dispute_votes (
+                        id VARCHAR(255) PRIMARY KEY,
+                        dispute_id VARCHAR(255) NOT NULL REFERENCES disputes(id),
+                        voter_id VARCHAR(255) NOT NULL REFERENCES users(id),
+                        vote VARCHAR(10) NOT NULL,
+                        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+                        UNIQUE(dispute_id, voter_id)
+                    )
+                """)
+                
                 # Create indexes for common queries
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_resolution_votes_market ON resolution_votes(market_id)")
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_comments_market ON comments(market_id)")
@@ -500,6 +539,12 @@ class Storage:
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_markets_closes_at ON markets(closes_at)")
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_users_status ON users(status)")
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_users_lower_username ON users(LOWER(username))")
+                
+                # Dispute indexes
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_disputes_market ON disputes(market_id)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_disputes_status ON disputes(status)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_dispute_votes_dispute ON dispute_votes(dispute_id)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_dispute_votes_voter ON dispute_votes(voter_id)")
                 
                 conn.commit()
                 print("Database tables initialized")
@@ -541,6 +586,7 @@ class Storage:
             "created_at": row["created_at"],
             "resolved_at": row["resolved_at"],
             "resolution": Outcome(row["resolution"].upper()) if row["resolution"] else None,
+            "dispute_window_ends": row.get("dispute_window_ends"),
             "total_volume": float(row["total_volume"]),
             "creator_id": row["creator_id"],
             "pool": {"YES": float(row["pool_yes"]), "NO": float(row["pool_no"])},
@@ -935,6 +981,7 @@ class Storage:
                 "created_at": datetime.now(timezone.utc),
                 "resolved_at": None,
                 "resolution": None,
+                "dispute_window_ends": None,
                 "total_volume": 0.0,
                 "creator_id": creator_id,
                 "pool": pool,
@@ -1001,11 +1048,15 @@ class Storage:
             self._put_conn(conn)
     
     def resolve_market(self, market_id: str, outcome: Outcome):
+        now = datetime.now(timezone.utc)
+        dispute_window_ends = now + timedelta(hours=DISPUTE_WINDOW_HOURS)
+        
         if self._use_memory:
             market = self._markets[market_id]
             market["status"] = MarketStatus.RESOLVED
             market["resolution"] = outcome
-            market["resolved_at"] = datetime.now(timezone.utc)
+            market["resolved_at"] = now
+            market["dispute_window_ends"] = dispute_window_ends
             return
         
         conn = self._get_conn()
@@ -1013,9 +1064,9 @@ class Storage:
             with conn.cursor() as cur:
                 cur.execute("""
                     UPDATE markets 
-                    SET status = %s, resolution = %s, resolved_at = %s
+                    SET status = %s, resolution = %s, resolved_at = %s, dispute_window_ends = %s
                     WHERE id = %s
-                """, (MarketStatus.RESOLVED.value, outcome.value, datetime.now(timezone.utc), market_id))
+                """, (MarketStatus.RESOLVED.value, outcome.value, now, dispute_window_ends, market_id))
                 conn.commit()
         finally:
             self._put_conn(conn)
@@ -1518,6 +1569,264 @@ class Storage:
         finally:
             self._put_conn(conn)
     
+    # --- Disputes ---
+    
+    def create_dispute(self, dispute_id: str, market_id: str, disputor_id: str,
+                       reason: str, original_resolution: str) -> dict:
+        """Create a new dispute on a resolved market."""
+        now = datetime.now(timezone.utc)
+        dispute = {
+            "id": dispute_id,
+            "market_id": market_id,
+            "disputor_id": disputor_id,
+            "reason": reason,
+            "status": "OPEN",
+            "original_resolution": original_resolution,
+            "created_at": now,
+            "resolved_at": None,
+        }
+        
+        if self._use_memory:
+            if not hasattr(self, '_disputes'):
+                self._disputes = {}
+            self._disputes[dispute_id] = dispute
+            return dispute
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO disputes (id, market_id, disputor_id, reason, status, original_resolution, created_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """, (dispute_id, market_id, disputor_id, reason, "OPEN", original_resolution, now))
+                conn.commit()
+        finally:
+            self._put_conn(conn)
+        return dispute
+    
+    def get_disputes_for_market(self, market_id: str) -> List[dict]:
+        """Get all disputes for a market, ordered by creation time."""
+        if self._use_memory:
+            if not hasattr(self, '_disputes'):
+                return []
+            return sorted(
+                [d for d in self._disputes.values() if d["market_id"] == market_id],
+                key=lambda x: x["created_at"]
+            )
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT d.*, u.username AS disputor_username
+                    FROM disputes d
+                    LEFT JOIN users u ON d.disputor_id = u.id
+                    WHERE d.market_id = %s
+                    ORDER BY d.created_at ASC
+                """, (market_id,))
+                rows = cur.fetchall()
+                return [dict(row) for row in rows]
+        finally:
+            self._put_conn(conn)
+    
+    def get_dispute(self, dispute_id: str) -> Optional[dict]:
+        """Get a single dispute by ID."""
+        if self._use_memory:
+            if not hasattr(self, '_disputes'):
+                return None
+            return self._disputes.get(dispute_id)
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT d.*, u.username AS disputor_username
+                    FROM disputes d
+                    LEFT JOIN users u ON d.disputor_id = u.id
+                    WHERE d.id = %s
+                """, (dispute_id,))
+                row = cur.fetchone()
+                return dict(row) if row else None
+        finally:
+            self._put_conn(conn)
+    
+    def get_open_dispute_for_market(self, market_id: str) -> Optional[dict]:
+        """Get the currently open dispute for a market (if any)."""
+        if self._use_memory:
+            if not hasattr(self, '_disputes'):
+                return None
+            for d in self._disputes.values():
+                if d["market_id"] == market_id and d["status"] == "OPEN":
+                    return d
+            return None
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT d.*, u.username AS disputor_username
+                    FROM disputes d
+                    LEFT JOIN users u ON d.disputor_id = u.id
+                    WHERE d.market_id = %s AND d.status = 'OPEN'
+                    LIMIT 1
+                """, (market_id,))
+                row = cur.fetchone()
+                return dict(row) if row else None
+        finally:
+            self._put_conn(conn)
+    
+    def update_dispute_status(self, dispute_id: str, status: str):
+        """Update a dispute's status (OPEN → UPHELD or REJECTED)."""
+        now = datetime.now(timezone.utc)
+        if self._use_memory:
+            if hasattr(self, '_disputes') and dispute_id in self._disputes:
+                self._disputes[dispute_id]["status"] = status
+                self._disputes[dispute_id]["resolved_at"] = now
+            return
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    UPDATE disputes SET status = %s, resolved_at = %s WHERE id = %s
+                """, (status, now, dispute_id))
+                conn.commit()
+        finally:
+            self._put_conn(conn)
+    
+    def create_dispute_vote(self, vote_id: str, dispute_id: str, voter_id: str, vote: str) -> dict:
+        """Record a vote on a dispute."""
+        now = datetime.now(timezone.utc)
+        vote_record = {
+            "id": vote_id,
+            "dispute_id": dispute_id,
+            "voter_id": voter_id,
+            "vote": vote,
+            "created_at": now,
+        }
+        
+        if self._use_memory:
+            if not hasattr(self, '_dispute_votes'):
+                self._dispute_votes = {}
+            self._dispute_votes[vote_id] = vote_record
+            return vote_record
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO dispute_votes (id, dispute_id, voter_id, vote, created_at)
+                    VALUES (%s, %s, %s, %s, %s)
+                """, (vote_id, dispute_id, voter_id, vote, now))
+                conn.commit()
+        finally:
+            self._put_conn(conn)
+        return vote_record
+    
+    def get_dispute_votes(self, dispute_id: str) -> List[dict]:
+        """Get all votes for a dispute."""
+        if self._use_memory:
+            if not hasattr(self, '_dispute_votes'):
+                return []
+            return [v for v in self._dispute_votes.values() if v["dispute_id"] == dispute_id]
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT dv.*, u.username AS voter_username
+                    FROM dispute_votes dv
+                    LEFT JOIN users u ON dv.voter_id = u.id
+                    WHERE dv.dispute_id = %s
+                    ORDER BY dv.created_at ASC
+                """, (dispute_id,))
+                rows = cur.fetchall()
+                return [dict(row) for row in rows]
+        finally:
+            self._put_conn(conn)
+    
+    def has_user_voted_on_dispute(self, dispute_id: str, voter_id: str) -> bool:
+        """Check if a user has already voted on a dispute."""
+        if self._use_memory:
+            if not hasattr(self, '_dispute_votes'):
+                return False
+            return any(v["dispute_id"] == dispute_id and v["voter_id"] == voter_id
+                       for v in self._dispute_votes.values())
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT 1 FROM dispute_votes WHERE dispute_id = %s AND voter_id = %s
+                """, (dispute_id, voter_id))
+                return cur.fetchone() is not None
+        finally:
+            self._put_conn(conn)
+    
+    def get_top_traders_for_market(self, market_id: str, limit: int = 5) -> List[dict]:
+        """Get top N traders by volume on a market (for dispute voting eligibility).
+        
+        Returns list of dicts with user_id, username, and total_volume.
+        """
+        if self._use_memory:
+            volume_by_user = {}
+            for b in self._bets.values():
+                if b["market_id"] == market_id:
+                    uid = b["user_id"]
+                    volume_by_user[uid] = volume_by_user.get(uid, 0) + b["amount"]
+            traders = sorted(volume_by_user.items(), key=lambda x: x[1], reverse=True)[:limit]
+            result = []
+            for uid, vol in traders:
+                user = self._users.get(uid)
+                result.append({
+                    "user_id": uid,
+                    "username": user["username"] if user else "unknown",
+                    "total_volume": vol,
+                })
+            return result
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT b.user_id, u.username, SUM(b.amount) AS total_volume
+                    FROM bets b
+                    LEFT JOIN users u ON b.user_id = u.id
+                    WHERE b.market_id = %s
+                    GROUP BY b.user_id, u.username
+                    ORDER BY total_volume DESC
+                    LIMIT %s
+                """, (market_id, limit))
+                rows = cur.fetchall()
+                return [
+                    {
+                        "user_id": row["user_id"],
+                        "username": row["username"] or "unknown",
+                        "total_volume": float(row["total_volume"]),
+                    }
+                    for row in rows
+                ]
+        finally:
+            self._put_conn(conn)
+    
+    def update_market_resolution(self, market_id: str, outcome: Outcome, status: MarketStatus):
+        """Update a market's resolution and status (used for dispute re-resolution)."""
+        if self._use_memory:
+            market = self._markets[market_id]
+            market["resolution"] = outcome
+            market["status"] = status
+            return
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    UPDATE markets SET resolution = %s, status = %s WHERE id = %s
+                """, (outcome.value, status.value, market_id))
+                conn.commit()
+        finally:
+            self._put_conn(conn)
+    
     # --- Chat Messages ---
     
     def create_chat_message(self, user_id: str, username: str, text: str, channel: str = "agents") -> dict:
@@ -1772,6 +2081,27 @@ app.add_middleware(
 # Payout Helper
 # =============================================================================
 
+def _reverse_payouts(market_id: str, old_outcome: Outcome) -> int:
+    """Reverse payouts from a previous resolution (used when a dispute flips the outcome).
+
+    Claws back payouts from original winners (they got 1ŧ per winning share).
+    Also reverses the profit adjustment so profit_all_time is clean.
+
+    Returns:
+        Number of positions that had payouts reversed.
+    """
+    positions = db.get_market_positions(market_id)
+    reversed_count = 0
+    for pos in positions:
+        winning_shares = pos["yes_shares"] if old_outcome == Outcome.YES else pos["no_shares"]
+        if winning_shares > 0:
+            payout = winning_shares
+            db.update_user_balance(pos["user_id"], -payout)
+            db.update_user_profit(pos["user_id"], -(payout - pos["total_invested"]))
+            reversed_count += 1
+    return reversed_count
+
+
 def _calculate_and_distribute_payouts(market_id: str, outcome: Outcome) -> int:
     """Calculate and distribute payouts to winning position holders for a resolved market.
 
@@ -1834,9 +2164,11 @@ async def list_markets(status: Optional[str] = None):
     if status_filter == "ALL":
         pass  # no filtering
     elif status_filter in ("CLOSED", "RESOLVED"):
-        markets = [m for m in markets if m["status"] == MarketStatus.RESOLVED]
+        markets = [m for m in markets if m["status"] in (MarketStatus.RESOLVED, MarketStatus.RE_RESOLVED)]
     elif status_filter == "RESOLVING":
         markets = [m for m in markets if m["status"] == MarketStatus.RESOLVING]
+    elif status_filter == "DISPUTED":
+        markets = [m for m in markets if m["status"] == MarketStatus.DISPUTED]
     else:
         # Default: only open markets (ACTIVE or OPEN both map here)
         markets = [m for m in markets if m["status"] == MarketStatus.OPEN]
@@ -1883,6 +2215,7 @@ async def get_market(market_id: str):
         created_at=market["created_at"],
         resolved_at=market["resolved_at"],
         resolution=market["resolution"],
+        dispute_window_ends=market.get("dispute_window_ends"),
         total_volume=market["total_volume"],
         creator_id=market["creator_id"],
         creator_username=creator_username,
@@ -2026,6 +2359,7 @@ async def resolve_market(market_id: str, req: MarketResolve, user: dict = Depend
         created_at=market["created_at"],
         resolved_at=market["resolved_at"],
         resolution=market["resolution"],
+        dispute_window_ends=market.get("dispute_window_ends"),
         total_volume=market["total_volume"],
         creator_id=market["creator_id"],
         creator_username=creator_username,
@@ -2582,6 +2916,280 @@ async def get_resolution_votes(market_id: str):
             for v in votes
         ],
         resolved_at=market.get("resolved_at"),
+    )
+
+
+# =============================================================================
+# Dispute Endpoints
+# =============================================================================
+
+def _resolve_dispute(dispute_id: str, market_id: str, original_resolution: Outcome):
+    """Check if all eligible voters have voted and resolve the dispute if so.
+    
+    Called after each vote. If all eligible voters have voted (or enough to
+    determine the outcome), resolves the dispute:
+      - Majority disagrees with original → UPHELD (outcome flips)
+      - Majority agrees with original → REJECTED (original stands)
+    """
+    dispute = db.get_dispute(dispute_id)
+    if not dispute or dispute["status"] != "OPEN":
+        return
+    
+    votes = db.get_dispute_votes(dispute_id)
+    eligible = db.get_top_traders_for_market(market_id, limit=DISPUTE_VOTER_COUNT)
+    eligible_ids = {t["user_id"] for t in eligible}
+    total_eligible = len(eligible_ids)
+    
+    if total_eligible == 0:
+        return
+    
+    # Count votes
+    votes_for_original = sum(1 for v in votes if v["vote"] == original_resolution.value)
+    votes_against_original = sum(1 for v in votes if v["vote"] != original_resolution.value)
+    total_votes = len(votes)
+    
+    majority_threshold = (total_eligible // 2) + 1
+    
+    # Can we determine the outcome?
+    # Either all eligible voted, or one side has an unassailable majority
+    all_voted = total_votes >= total_eligible
+    original_wins = votes_for_original >= majority_threshold
+    challenger_wins = votes_against_original >= majority_threshold
+    
+    if not (all_voted or original_wins or challenger_wins):
+        return  # Not enough votes yet
+    
+    if votes_against_original > votes_for_original:
+        # Dispute UPHELD — flip the outcome
+        db.update_dispute_status(dispute_id, "UPHELD")
+        
+        # Reverse old payouts, apply new ones
+        _reverse_payouts(market_id, original_resolution)
+        new_outcome = Outcome.NO if original_resolution == Outcome.YES else Outcome.YES
+        db.update_market_resolution(market_id, new_outcome, MarketStatus.RE_RESOLVED)
+        _calculate_and_distribute_payouts(market_id, new_outcome)
+    else:
+        # Dispute REJECTED — original resolution stands
+        db.update_dispute_status(dispute_id, "REJECTED")
+        db.update_market_status(market_id, MarketStatus.RESOLVED)
+
+
+@app.post("/markets/{market_id}/dispute", response_model=DisputeDetail, tags=["markets"])
+async def file_dispute(market_id: str, req: DisputeCreate, user: dict = Depends(require_auth)):
+    """File a dispute on a resolved market.
+    
+    Any trader who has a position on the market can dispute within 24 hours
+    of resolution. This triggers a re-resolution vote by the top traders
+    (by volume) on the market.
+    
+    One dispute round only — no appeals after re-resolution.
+    """
+    _validate_uuid(market_id, "market_id")
+    market = db.get_market(market_id)
+    if not market:
+        raise HTTPException(status_code=404, detail="Market not found")
+    
+    # Must be resolved (not already disputed/re-resolved)
+    if market["status"] not in (MarketStatus.RESOLVED,):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Can only dispute RESOLVED markets. Current status: {market['status'].value}"
+        )
+    
+    # Check dispute window
+    now = datetime.now(timezone.utc)
+    dispute_window_ends = market.get("dispute_window_ends")
+    if dispute_window_ends:
+        if isinstance(dispute_window_ends, str):
+            dispute_window_ends = datetime.fromisoformat(dispute_window_ends.replace('Z', '+00:00'))
+        if now > dispute_window_ends:
+            raise HTTPException(
+                status_code=400,
+                detail="Dispute window has expired (24 hours after resolution)"
+            )
+    
+    # Must have a position (must be a trader on this market)
+    position = db.get_position(market_id, user["id"])
+    if not position or (position["yes_shares"] <= 0 and position["no_shares"] <= 0):
+        raise HTTPException(
+            status_code=403,
+            detail="Only traders with a position on this market can file disputes"
+        )
+    
+    # Check no open dispute already exists
+    existing = db.get_open_dispute_for_market(market_id)
+    if existing:
+        raise HTTPException(
+            status_code=400,
+            detail="There is already an open dispute on this market"
+        )
+    
+    # Check no previous dispute was already resolved (one round only)
+    all_disputes = db.get_disputes_for_market(market_id)
+    if any(d["status"] in ("UPHELD", "REJECTED") for d in all_disputes):
+        raise HTTPException(
+            status_code=400,
+            detail="This market has already been through a dispute round. No appeals allowed."
+        )
+    
+    # Get eligible voters (top N traders by volume)
+    eligible = db.get_top_traders_for_market(market_id, limit=DISPUTE_VOTER_COUNT)
+    if len(eligible) < 1:
+        raise HTTPException(
+            status_code=400,
+            detail="Not enough traders on this market to form a dispute committee"
+        )
+    
+    # Create the dispute
+    dispute_id = str(uuid.uuid4())
+    original_resolution = market["resolution"].value
+    dispute = db.create_dispute(
+        dispute_id=dispute_id,
+        market_id=market_id,
+        disputor_id=user["id"],
+        reason=req.reason,
+        original_resolution=original_resolution,
+    )
+    
+    # Transition market to DISPUTED
+    db.update_market_status(market_id, MarketStatus.DISPUTED)
+    
+    return DisputeDetail(
+        id=dispute["id"],
+        market_id=market_id,
+        disputor_id=user["id"],
+        disputor_username=user["username"],
+        reason=req.reason,
+        status=DisputeStatus.OPEN,
+        original_resolution=Outcome(original_resolution),
+        created_at=dispute["created_at"],
+        eligible_voters=len(eligible),
+        votes_for_original=0,
+        votes_against_original=0,
+    )
+
+
+@app.post("/markets/{market_id}/disputes/{dispute_id}/vote", response_model=DisputeVoteResponse, tags=["markets"])
+async def vote_on_dispute(market_id: str, dispute_id: str, req: DisputeVoteRequest, user: dict = Depends(require_auth)):
+    """Vote on an open dispute.
+    
+    Only the top N traders (by volume) on the market are eligible to vote.
+    Each eligible voter gets one vote — what they believe the correct outcome is.
+    
+    Once all eligible voters have voted (or a majority is reached),
+    the dispute is automatically resolved.
+    """
+    _validate_uuid(market_id, "market_id")
+    _validate_uuid(dispute_id, "dispute_id")
+    
+    market = db.get_market(market_id)
+    if not market:
+        raise HTTPException(status_code=404, detail="Market not found")
+    
+    dispute = db.get_dispute(dispute_id)
+    if not dispute:
+        raise HTTPException(status_code=404, detail="Dispute not found")
+    
+    if dispute["market_id"] != market_id:
+        raise HTTPException(status_code=400, detail="Dispute does not belong to this market")
+    
+    if dispute["status"] != "OPEN":
+        raise HTTPException(status_code=400, detail=f"Dispute is already {dispute['status']}")
+    
+    # Check voter eligibility (must be top N trader by volume)
+    eligible = db.get_top_traders_for_market(market_id, limit=DISPUTE_VOTER_COUNT)
+    eligible_ids = {t["user_id"] for t in eligible}
+    
+    if user["id"] not in eligible_ids:
+        raise HTTPException(
+            status_code=403,
+            detail="Only the top traders (by volume) on this market are eligible to vote on disputes"
+        )
+    
+    # Check if already voted
+    if db.has_user_voted_on_dispute(dispute_id, user["id"]):
+        raise HTTPException(status_code=400, detail="You have already voted on this dispute")
+    
+    # Record vote
+    vote_id = str(uuid.uuid4())
+    vote_record = db.create_dispute_vote(vote_id, dispute_id, user["id"], req.vote.value)
+    
+    # Try to resolve the dispute (will no-op if not enough votes yet)
+    original_resolution = Outcome(dispute["original_resolution"])
+    _resolve_dispute(dispute_id, market_id, original_resolution)
+    
+    return DisputeVoteResponse(
+        voter_id=user["id"],
+        voter_username=user["username"],
+        vote=req.vote,
+        created_at=vote_record["created_at"],
+    )
+
+
+@app.get("/markets/{market_id}/disputes", response_model=DisputeListResponse, tags=["markets"])
+async def list_disputes(market_id: str):
+    """List all disputes for a market and their status.
+    
+    Includes vote tallies and eligible voter count for each dispute.
+    """
+    _validate_uuid(market_id, "market_id")
+    market = db.get_market(market_id)
+    if not market:
+        raise HTTPException(status_code=404, detail="Market not found")
+    
+    raw_disputes = db.get_disputes_for_market(market_id)
+    eligible = db.get_top_traders_for_market(market_id, limit=DISPUTE_VOTER_COUNT)
+    
+    disputes = []
+    for d in raw_disputes:
+        votes = db.get_dispute_votes(d["id"])
+        original_res = d["original_resolution"]
+        
+        votes_for = sum(1 for v in votes if v["vote"] == original_res)
+        votes_against = sum(1 for v in votes if v["vote"] != original_res)
+        
+        # Determine final resolution for completed disputes
+        final_resolution = None
+        if d["status"] == "UPHELD":
+            final_resolution = Outcome.NO if original_res == "YES" else Outcome.YES
+        elif d["status"] == "REJECTED":
+            final_resolution = Outcome(original_res)
+        
+        # Get disputor username
+        disputor_username = d.get("disputor_username")
+        if not disputor_username:
+            disputor = db.get_user(d["disputor_id"])
+            disputor_username = disputor["username"] if disputor else None
+        
+        disputes.append(DisputeDetail(
+            id=d["id"],
+            market_id=d["market_id"],
+            disputor_id=d["disputor_id"],
+            disputor_username=disputor_username,
+            reason=d["reason"],
+            status=DisputeStatus(d["status"]),
+            original_resolution=Outcome(d["original_resolution"]),
+            final_resolution=final_resolution,
+            created_at=d["created_at"],
+            resolved_at=d.get("resolved_at"),
+            votes=[
+                DisputeVoteResponse(
+                    voter_id=v["voter_id"],
+                    voter_username=v.get("voter_username", "unknown"),
+                    vote=Outcome(v["vote"]),
+                    created_at=v["created_at"],
+                )
+                for v in votes
+            ],
+            eligible_voters=len(eligible),
+            votes_for_original=votes_for,
+            votes_against_original=votes_against,
+        ))
+    
+    return DisputeListResponse(
+        market_id=market_id,
+        disputes=disputes,
+        dispute_window_ends=market.get("dispute_window_ends"),
     )
 
 
@@ -3356,6 +3964,9 @@ curl -X POST https://moltmarkets-api-production.up.railway.app/markets/MARKET_ID
 | GET | `/markets/{{id}}/history` | No | Price history |
 | GET | `/markets/{{id}}/comments` | No | List comments |
 | POST | `/markets/{{id}}/comments` | Yes | Add a comment |
+| POST | `/markets/{{id}}/dispute` | Yes | File a dispute (within 24h of resolution) |
+| POST | `/markets/{{id}}/disputes/{{did}}/vote` | Yes | Vote on an open dispute (top traders only) |
+| GET | `/markets/{{id}}/disputes` | No | List disputes and their status |
 
 ### Trading
 

--- a/migrations/005_add_disputes.sql
+++ b/migrations/005_add_disputes.sql
@@ -1,0 +1,48 @@
+-- Migration 005: Add dispute system tables and columns
+-- Issue: https://github.com/shirtlessfounder/moltmarkets-api/issues/8
+--
+-- Adds multi-resolver dispute mechanism:
+--   - Any trader can dispute within 24h of resolution
+--   - Top N traders (by volume) vote on re-resolution
+--   - Majority flips outcome or rejects dispute
+--   - One dispute round only, no appeals
+--
+-- New status flow: RESOLVED → DISPUTED → RE_RESOLVED (or back to RESOLVED)
+--
+-- Safe to run multiple times (IF NOT EXISTS / DO blocks).
+
+-- Add dispute_window_ends to markets (24h after resolution)
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='markets' AND column_name='dispute_window_ends') THEN
+        ALTER TABLE markets ADD COLUMN dispute_window_ends TIMESTAMP WITH TIME ZONE;
+    END IF;
+END $$;
+
+-- Disputes table
+CREATE TABLE IF NOT EXISTS disputes (
+    id VARCHAR(255) PRIMARY KEY,
+    market_id VARCHAR(255) NOT NULL REFERENCES markets(id),
+    disputor_id VARCHAR(255) NOT NULL REFERENCES users(id),
+    reason TEXT NOT NULL,
+    status VARCHAR(50) NOT NULL DEFAULT 'OPEN',   -- OPEN, UPHELD, REJECTED
+    original_resolution VARCHAR(10) NOT NULL,       -- YES or NO (snapshot of what was disputed)
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    resolved_at TIMESTAMP WITH TIME ZONE            -- when voting concluded
+);
+
+-- Dispute votes table (top N traders vote)
+CREATE TABLE IF NOT EXISTS dispute_votes (
+    id VARCHAR(255) PRIMARY KEY,
+    dispute_id VARCHAR(255) NOT NULL REFERENCES disputes(id),
+    voter_id VARCHAR(255) NOT NULL REFERENCES users(id),
+    vote VARCHAR(10) NOT NULL,                       -- YES or NO (what they think outcome should be)
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE(dispute_id, voter_id)                     -- one vote per voter per dispute
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_disputes_market ON disputes(market_id);
+CREATE INDEX IF NOT EXISTS idx_disputes_status ON disputes(status);
+CREATE INDEX IF NOT EXISTS idx_dispute_votes_dispute ON dispute_votes(dispute_id);
+CREATE INDEX IF NOT EXISTS idx_dispute_votes_voter ON dispute_votes(voter_id);

--- a/models.py
+++ b/models.py
@@ -24,6 +24,8 @@ class MarketStatus(str, Enum):
     RESOLVING = "RESOLVING"
     CLOSED = "CLOSED"
     RESOLVED = "RESOLVED"
+    DISPUTED = "DISPUTED"
+    RE_RESOLVED = "RE_RESOLVED"
 
 
 # =============================================================================
@@ -96,6 +98,7 @@ class MarketDetail(BaseModel):
     created_at: datetime
     resolved_at: Optional[datetime] = None
     resolution: Optional[Outcome] = None
+    dispute_window_ends: Optional[datetime] = None
     total_volume: float
     creator_id: str
     creator_username: Optional[str] = None
@@ -524,6 +527,59 @@ class ChatMessage(BaseModel):
 # =============================================================================
 # Resolution Models (continued)
 # =============================================================================
+
+# =============================================================================
+# Dispute Models
+# =============================================================================
+
+class DisputeStatus(str, Enum):
+    OPEN = "OPEN"
+    UPHELD = "UPHELD"       # Dispute won — outcome flipped
+    REJECTED = "REJECTED"   # Dispute lost — original stands
+
+
+class DisputeCreate(BaseModel):
+    """Request to file a dispute on a resolved market."""
+    reason: str = Field(..., min_length=10, max_length=2000)
+
+
+class DisputeVoteRequest(BaseModel):
+    """Request to vote on a dispute (eligible voters only)."""
+    vote: Outcome  # What the voter thinks the outcome should be
+
+
+class DisputeVoteResponse(BaseModel):
+    """A single vote on a dispute."""
+    voter_id: str
+    voter_username: str
+    vote: Outcome
+    created_at: datetime
+
+
+class DisputeDetail(BaseModel):
+    """Full dispute details including votes."""
+    id: str
+    market_id: str
+    disputor_id: str
+    disputor_username: Optional[str] = None
+    reason: str
+    status: DisputeStatus
+    original_resolution: Outcome
+    final_resolution: Optional[Outcome] = None
+    created_at: datetime
+    resolved_at: Optional[datetime] = None
+    votes: List[DisputeVoteResponse] = []
+    eligible_voters: int = 0
+    votes_for_original: int = 0
+    votes_against_original: int = 0
+
+
+class DisputeListResponse(BaseModel):
+    """List of disputes for a market."""
+    market_id: str
+    disputes: List[DisputeDetail]
+    dispute_window_ends: Optional[datetime] = None
+
 
 class ResolutionVote(BaseModel):
     """A single resolver agent's vote."""

--- a/test_disputes.py
+++ b/test_disputes.py
@@ -1,0 +1,705 @@
+"""
+Tests for the multi-resolver dispute system (issue #8).
+
+Tests the full dispute lifecycle:
+  1. Market resolution sets dispute_window_ends
+  2. Traders can file disputes within the 24h window
+  3. Top N traders by volume are eligible to vote
+  4. Majority disagreement flips the outcome (UPHELD)
+  5. Majority agreement rejects the dispute (REJECTED)
+  6. Status transitions: RESOLVED → DISPUTED → RE_RESOLVED / RESOLVED
+  7. Payouts are reversed and re-distributed on flip
+  8. One dispute round only, no appeals
+"""
+
+import pytest
+import uuid
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+# Patch DATABASE_URL before importing api (force in-memory storage)
+import os
+os.environ.pop("DATABASE_URL", None)
+
+from api import app, db, DISPUTE_WINDOW_HOURS, DISPUTE_VOTER_COUNT, hash_api_key, generate_api_key
+from models import MarketStatus, Outcome
+
+
+client = TestClient(app)
+
+
+# =============================================================================
+# Fixtures / Helpers
+# =============================================================================
+
+def _create_user(username: str, balance: float = 1000.0, claimed: bool = True) -> tuple[dict, str]:
+    """Create a user and return (user_dict, raw_api_key)."""
+    api_key = generate_api_key()
+    user_id = str(uuid.uuid4())
+    user = db.create_user(
+        user_id=user_id,
+        username=username,
+        balance=balance,
+        api_key_hash=hash_api_key(api_key),
+        status="claimed" if claimed else "pending",
+    )
+    return user, api_key
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _create_resolved_market(creator_id: str, outcome: Outcome = Outcome.YES) -> dict:
+    """Create and immediately resolve a market (bypassing time checks)."""
+    market_id = str(uuid.uuid4())
+    market = db.create_market(
+        market_id=market_id,
+        creator_id=creator_id,
+        title="Test market for disputes",
+        description="Will resolve for testing",
+        closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        initial_liquidity=100.0,
+    )
+    db.resolve_market(market_id, outcome)
+    return db.get_market(market_id)
+
+
+def _place_bet(market_id: str, user_id: str, outcome: Outcome, amount: float):
+    """Place a bet directly via storage (bypass API checks)."""
+    from cpmm import CpmmState, calculate_cpmm_purchase, get_cpmm_probability
+    
+    market = db.get_market(market_id)
+    state = CpmmState(pool=market["pool"].copy(), p=market["p"])
+    prob_before = get_cpmm_probability(market["pool"], market["p"])
+    result = calculate_cpmm_purchase(state, amount, outcome.value)
+    shares = result["shares"]
+    prob_after = get_cpmm_probability(result["new_pool"], result["new_p"])
+    
+    db.update_user_balance(user_id, -amount)
+    db.update_market_pool(market_id, result["new_pool"], result["new_p"], amount)
+    db.update_position(market_id, user_id, outcome, shares, amount)
+    
+    bet_id = str(uuid.uuid4())
+    db.create_bet(
+        bet_id=bet_id,
+        market_id=market_id,
+        user_id=user_id,
+        outcome=outcome,
+        amount=amount,
+        shares=shares,
+        prob_before=prob_before,
+        prob_after=prob_after,
+    )
+    return shares
+
+
+# =============================================================================
+# Tests: Resolution sets dispute_window_ends
+# =============================================================================
+
+class TestResolutionSetsDisputeWindow:
+    def test_resolve_sets_dispute_window(self):
+        """Resolving a market should set dispute_window_ends to 24h later."""
+        creator, _ = _create_user(f"creator_{uuid.uuid4().hex[:8]}")
+        market = _create_resolved_market(creator["id"])
+        
+        assert market["dispute_window_ends"] is not None
+        assert market["status"] == MarketStatus.RESOLVED
+        
+        # Window should be ~24h after resolved_at
+        window_delta = market["dispute_window_ends"] - market["resolved_at"]
+        assert abs(window_delta.total_seconds() - DISPUTE_WINDOW_HOURS * 3600) < 5
+
+
+# =============================================================================
+# Tests: Filing Disputes
+# =============================================================================
+
+class TestFileDispute:
+    def test_trader_can_dispute_resolved_market(self):
+        """A trader with a position can file a dispute on a resolved market."""
+        creator, creator_key = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        trader, trader_key = _create_user(f"t_{uuid.uuid4().hex[:8]}")
+        
+        # Create market, place bet, then resolve
+        market_id = str(uuid.uuid4())
+        market = db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="Disputable market",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        _place_bet(market_id, trader["id"], Outcome.NO, 50)
+        db.resolve_market(market_id, Outcome.YES)
+        
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "The resolution is incorrect based on the evidence"},
+            headers=_auth(trader_key),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "OPEN"
+        assert data["original_resolution"] == "YES"
+        assert data["disputor_id"] == trader["id"]
+        
+        # Market should now be DISPUTED
+        market = db.get_market(market_id)
+        assert market["status"] == MarketStatus.DISPUTED
+    
+    def test_non_trader_cannot_dispute(self):
+        """A user without a position cannot file a dispute."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        outsider, outsider_key = _create_user(f"o_{uuid.uuid4().hex[:8]}")
+        
+        market = _create_resolved_market(creator["id"])
+        
+        resp = client.post(
+            f"/markets/{market['id']}/dispute",
+            json={"reason": "I think this is wrong even though I didn't trade"},
+            headers=_auth(outsider_key),
+        )
+        assert resp.status_code == 403
+    
+    def test_dispute_after_window_fails(self):
+        """Filing a dispute after the 24h window should fail."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        trader, trader_key = _create_user(f"t_{uuid.uuid4().hex[:8]}")
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="Expired dispute window",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        _place_bet(market_id, trader["id"], Outcome.NO, 50)
+        db.resolve_market(market_id, Outcome.YES)
+        
+        # Manually set dispute_window_ends to the past
+        if db._use_memory:
+            db._markets[market_id]["dispute_window_ends"] = datetime.now(timezone.utc) - timedelta(hours=1)
+        
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Too late to dispute this"},
+            headers=_auth(trader_key),
+        )
+        assert resp.status_code == 400
+        assert "expired" in resp.json()["detail"].lower()
+    
+    def test_cannot_dispute_non_resolved_market(self):
+        """Cannot dispute a market that isn't RESOLVED."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        trader, trader_key = _create_user(f"t_{uuid.uuid4().hex[:8]}")
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="Still open",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        _place_bet(market_id, trader["id"], Outcome.YES, 50)
+        
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Premature dispute attempt"},
+            headers=_auth(trader_key),
+        )
+        assert resp.status_code == 400
+    
+    def test_no_double_disputes(self):
+        """Cannot file a second dispute while one is open."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        trader1, trader1_key = _create_user(f"t1_{uuid.uuid4().hex[:8]}")
+        trader2, trader2_key = _create_user(f"t2_{uuid.uuid4().hex[:8]}")
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="Double dispute test",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        _place_bet(market_id, trader1["id"], Outcome.NO, 50)
+        _place_bet(market_id, trader2["id"], Outcome.NO, 30)
+        db.resolve_market(market_id, Outcome.YES)
+        
+        # First dispute succeeds
+        resp1 = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "First dispute"},
+            headers=_auth(trader1_key),
+        )
+        assert resp1.status_code == 200
+        
+        # Second dispute fails (market is now DISPUTED, not RESOLVED)
+        resp2 = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Second dispute"},
+            headers=_auth(trader2_key),
+        )
+        assert resp2.status_code == 400
+
+
+# =============================================================================
+# Tests: Voting on Disputes
+# =============================================================================
+
+class TestDisputeVoting:
+    def _setup_disputable_market(self, num_traders=5):
+        """Create a resolved market with N traders who have positions."""
+        creator, creator_key = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="Voting test market",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        
+        traders = []
+        for i in range(num_traders):
+            trader, key = _create_user(f"voter_{uuid.uuid4().hex[:8]}")
+            amount = 50 - i * 5  # Varying volumes: 50, 45, 40, ...
+            _place_bet(market_id, trader["id"], Outcome.NO, max(amount, 10))
+            traders.append((trader, key))
+        
+        db.resolve_market(market_id, Outcome.YES)
+        return market_id, creator, creator_key, traders
+    
+    def test_eligible_voter_can_vote(self):
+        """Top traders by volume can vote on disputes."""
+        market_id, creator, _, traders = self._setup_disputable_market(5)
+        
+        # File dispute
+        disputor, disputor_key = traders[0]
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Wrong outcome"},
+            headers=_auth(disputor_key),
+        )
+        assert resp.status_code == 200
+        dispute_id = resp.json()["id"]
+        
+        # Top trader votes
+        voter, voter_key = traders[1]
+        resp = client.post(
+            f"/markets/{market_id}/disputes/{dispute_id}/vote",
+            json={"vote": "NO"},
+            headers=_auth(voter_key),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["vote"] == "NO"
+    
+    def test_ineligible_voter_rejected(self):
+        """A user who isn't a top trader cannot vote."""
+        market_id, creator, _, traders = self._setup_disputable_market(5)
+        
+        # Create an outsider with tiny volume
+        outsider, outsider_key = _create_user(f"outsider_{uuid.uuid4().hex[:8]}")
+        _place_bet(market_id, outsider["id"], Outcome.YES, 1)  # Tiny volume
+        
+        # Re-resolve market (bet was placed on OPEN market, need to re-resolve)
+        # Actually the market was already resolved, so this bet went through storage directly
+        # The outsider won't be in top 5
+        
+        disputor, disputor_key = traders[0]
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Wrong outcome"},
+            headers=_auth(disputor_key),
+        )
+        dispute_id = resp.json()["id"]
+        
+        resp = client.post(
+            f"/markets/{market_id}/disputes/{dispute_id}/vote",
+            json={"vote": "NO"},
+            headers=_auth(outsider_key),
+        )
+        assert resp.status_code == 403
+    
+    def test_no_double_voting(self):
+        """A voter cannot vote twice on the same dispute."""
+        market_id, creator, _, traders = self._setup_disputable_market(5)
+        
+        disputor, disputor_key = traders[0]
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Wrong outcome"},
+            headers=_auth(disputor_key),
+        )
+        dispute_id = resp.json()["id"]
+        
+        voter, voter_key = traders[1]
+        
+        # First vote succeeds
+        resp1 = client.post(
+            f"/markets/{market_id}/disputes/{dispute_id}/vote",
+            json={"vote": "NO"},
+            headers=_auth(voter_key),
+        )
+        assert resp1.status_code == 200
+        
+        # Second vote fails
+        resp2 = client.post(
+            f"/markets/{market_id}/disputes/{dispute_id}/vote",
+            json={"vote": "YES"},
+            headers=_auth(voter_key),
+        )
+        assert resp2.status_code == 400
+
+
+# =============================================================================
+# Tests: Dispute Resolution (Outcome Flip vs Rejection)
+# =============================================================================
+
+class TestDisputeResolution:
+    def test_majority_against_flips_outcome(self):
+        """If majority votes against original resolution → UPHELD, outcome flips."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="Flip test",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        
+        # Create 5 traders (enough for DISPUTE_VOTER_COUNT=5)
+        traders = []
+        for i in range(5):
+            t, k = _create_user(f"flip_{uuid.uuid4().hex[:8]}")
+            _place_bet(market_id, t["id"], Outcome.NO, 50 - i * 5)
+            traders.append((t, k))
+        
+        db.resolve_market(market_id, Outcome.YES)
+        
+        # File dispute
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Should be NO"},
+            headers=_auth(traders[0][1]),
+        )
+        dispute_id = resp.json()["id"]
+        
+        # 3 out of 5 vote NO (against original YES) → majority
+        for i in range(3):
+            client.post(
+                f"/markets/{market_id}/disputes/{dispute_id}/vote",
+                json={"vote": "NO"},
+                headers=_auth(traders[i][1]),
+            )
+        
+        # Check dispute resolved as UPHELD
+        market = db.get_market(market_id)
+        assert market["status"] == MarketStatus.RE_RESOLVED
+        assert market["resolution"] == Outcome.NO
+        
+        # Check dispute status
+        dispute = db.get_dispute(dispute_id)
+        assert dispute["status"] == "UPHELD"
+    
+    def test_majority_agrees_rejects_dispute(self):
+        """If majority votes for original resolution → REJECTED, original stands."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="Reject test",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        
+        traders = []
+        for i in range(5):
+            t, k = _create_user(f"reject_{uuid.uuid4().hex[:8]}")
+            _place_bet(market_id, t["id"], Outcome.YES, 50 - i * 5)
+            traders.append((t, k))
+        
+        db.resolve_market(market_id, Outcome.YES)
+        
+        # File dispute
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "I disagree"},
+            headers=_auth(traders[0][1]),
+        )
+        dispute_id = resp.json()["id"]
+        
+        # 3 out of 5 vote YES (agreeing with original) → majority
+        for i in range(3):
+            client.post(
+                f"/markets/{market_id}/disputes/{dispute_id}/vote",
+                json={"vote": "YES"},
+                headers=_auth(traders[i][1]),
+            )
+        
+        # Market back to RESOLVED
+        market = db.get_market(market_id)
+        assert market["status"] == MarketStatus.RESOLVED
+        assert market["resolution"] == Outcome.YES
+        
+        dispute = db.get_dispute(dispute_id)
+        assert dispute["status"] == "REJECTED"
+    
+    def test_no_appeals_after_resolved_dispute(self):
+        """After a dispute is resolved, cannot file another one."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="No appeals",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        
+        traders = []
+        for i in range(5):
+            t, k = _create_user(f"appeal_{uuid.uuid4().hex[:8]}")
+            _place_bet(market_id, t["id"], Outcome.NO, 50 - i * 5)
+            traders.append((t, k))
+        
+        db.resolve_market(market_id, Outcome.YES)
+        
+        # First dispute
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "First dispute"},
+            headers=_auth(traders[0][1]),
+        )
+        dispute_id = resp.json()["id"]
+        
+        # Resolve it (3 vote NO → upheld)
+        for i in range(3):
+            client.post(
+                f"/markets/{market_id}/disputes/{dispute_id}/vote",
+                json={"vote": "NO"},
+                headers=_auth(traders[i][1]),
+            )
+        
+        # Try to file another dispute — should fail (market is RE_RESOLVED, not RESOLVED)
+        resp2 = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Second attempt"},
+            headers=_auth(traders[4][1]),
+        )
+        assert resp2.status_code == 400
+
+
+# =============================================================================
+# Tests: Payout Reversal on Flip
+# =============================================================================
+
+class TestPayoutReversal:
+    def test_payouts_reversed_on_flip(self):
+        """When a dispute flips the outcome, old winners lose payouts and new winners get paid."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}", balance=2000)
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="Payout reversal test",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        
+        # YES bettors and NO bettors
+        yes_traders = []
+        no_traders = []
+        for i in range(3):
+            t, k = _create_user(f"yes_{uuid.uuid4().hex[:8]}", balance=500)
+            _place_bet(market_id, t["id"], Outcome.YES, 50)
+            yes_traders.append((t, k))
+        
+        for i in range(3):
+            t, k = _create_user(f"no_{uuid.uuid4().hex[:8]}", balance=500)
+            _place_bet(market_id, t["id"], Outcome.NO, 60 - i * 5)  # 60, 55, 50 — top volume
+            no_traders.append((t, k))
+        
+        # Resolve as YES — YES bettors win initially
+        db.resolve_market(market_id, Outcome.YES)
+        from api import _calculate_and_distribute_payouts
+        _calculate_and_distribute_payouts(market_id, Outcome.YES)
+        
+        # Record balances before dispute
+        yes_balances_before = [db.get_user(t["id"])["balance"] for t, _ in yes_traders]
+        no_balances_before = [db.get_user(t["id"])["balance"] for t, _ in no_traders]
+        
+        # File dispute (NO trader with highest volume)
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Should be NO"},
+            headers=_auth(no_traders[0][1]),
+        )
+        dispute_id = resp.json()["id"]
+        
+        # Top 5 by volume vote NO (flip to NO)
+        # The top traders include both YES and NO bettors
+        eligible = db.get_top_traders_for_market(market_id, limit=DISPUTE_VOTER_COUNT)
+        eligible_keys = {}
+        for t, k in yes_traders + no_traders:
+            eligible_keys[t["id"]] = k
+        
+        votes_cast = 0
+        for voter in eligible:
+            if voter["user_id"] in eligible_keys:
+                client.post(
+                    f"/markets/{market_id}/disputes/{dispute_id}/vote",
+                    json={"vote": "NO"},
+                    headers=_auth(eligible_keys[voter["user_id"]]),
+                )
+                votes_cast += 1
+                if votes_cast >= 3:
+                    break
+        
+        # Market should now be RE_RESOLVED with NO
+        market = db.get_market(market_id)
+        assert market["status"] == MarketStatus.RE_RESOLVED
+        assert market["resolution"] == Outcome.NO
+        
+        # YES bettors should have lost their payouts
+        # NO bettors should have received new payouts
+        for t, _ in no_traders:
+            user = db.get_user(t["id"])
+            pos = db.get_position(market_id, t["id"])
+            # NO bettor should now have received payout for their NO shares
+            assert pos["no_shares"] > 0
+
+
+# =============================================================================
+# Tests: GET /markets/{id}/disputes
+# =============================================================================
+
+class TestListDisputes:
+    def test_list_disputes_empty(self):
+        """Listing disputes on a market with none returns empty."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        market = _create_resolved_market(creator["id"])
+        
+        resp = client.get(f"/markets/{market['id']}/disputes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["market_id"] == market["id"]
+        assert len(data["disputes"]) == 0
+        assert data["dispute_window_ends"] is not None
+    
+    def test_list_disputes_with_votes(self):
+        """Listing disputes includes vote tallies."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="List disputes test",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        
+        traders = []
+        for i in range(5):
+            t, k = _create_user(f"list_{uuid.uuid4().hex[:8]}")
+            _place_bet(market_id, t["id"], Outcome.NO, 50 - i * 5)
+            traders.append((t, k))
+        
+        db.resolve_market(market_id, Outcome.YES)
+        
+        # File dispute
+        resp = client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Testing list endpoint"},
+            headers=_auth(traders[0][1]),
+        )
+        dispute_id = resp.json()["id"]
+        
+        # Cast 2 votes
+        client.post(
+            f"/markets/{market_id}/disputes/{dispute_id}/vote",
+            json={"vote": "NO"},
+            headers=_auth(traders[1][1]),
+        )
+        client.post(
+            f"/markets/{market_id}/disputes/{dispute_id}/vote",
+            json={"vote": "YES"},
+            headers=_auth(traders[2][1]),
+        )
+        
+        # List disputes
+        resp = client.get(f"/markets/{market_id}/disputes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["disputes"]) == 1
+        
+        dispute = data["disputes"][0]
+        assert dispute["status"] == "OPEN"
+        assert dispute["original_resolution"] == "YES"
+        assert len(dispute["votes"]) == 2
+        assert dispute["votes_for_original"] == 1  # One YES vote
+        assert dispute["votes_against_original"] == 1  # One NO vote
+
+
+# =============================================================================
+# Tests: Market Status Filter
+# =============================================================================
+
+class TestMarketStatusFilter:
+    def test_disputed_status_filter(self):
+        """Markets with DISPUTED status show up in ?status=disputed."""
+        creator, _ = _create_user(f"c_{uuid.uuid4().hex[:8]}")
+        trader, trader_key = _create_user(f"t_{uuid.uuid4().hex[:8]}")
+        
+        market_id = str(uuid.uuid4())
+        db.create_market(
+            market_id=market_id,
+            creator_id=creator["id"],
+            title="Status filter test",
+            description="Test",
+            closes_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            initial_liquidity=100.0,
+        )
+        _place_bet(market_id, trader["id"], Outcome.NO, 50)
+        db.resolve_market(market_id, Outcome.YES)
+        
+        # File dispute to set status to DISPUTED
+        client.post(
+            f"/markets/{market_id}/dispute",
+            json={"reason": "Testing status filter"},
+            headers=_auth(trader_key),
+        )
+        
+        resp = client.get("/markets?status=disputed")
+        assert resp.status_code == 200
+        market_ids = [m["id"] for m in resp.json()]
+        assert market_id in market_ids
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements the multi-resolver dispute system from issue #8. Improves on Manifold's single-creator resolution model by letting traders challenge resolutions democratically.

## New Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| POST | `/markets/{id}/dispute` | Yes | File a dispute (with reason text) |
| POST | `/markets/{id}/disputes/{did}/vote` | Yes | Vote on an open dispute |
| GET | `/markets/{id}/disputes` | No | List disputes with vote tallies |

## How It Works

1. After a market is resolved, a 24-hour dispute window opens (`dispute_window_ends` field)
2. Any trader **with a position** can file a dispute with a reason
3. The **top 5 traders by volume** on that market become eligible voters
4. Each eligible voter casts one vote (what they think the outcome should be)
5. Once a majority is reached or all votes are in:
   - **Majority disagrees** with original → dispute **UPHELD**, outcome flips, payouts reversed & redistributed
   - **Majority agrees** → dispute **REJECTED**, original resolution stands
6. **One round only** — no appeals after re-resolution

## Status Flow

```
RESOLVED → DISPUTED → RE_RESOLVED  (dispute upheld, outcome flipped)
                    → RESOLVED      (dispute rejected, original stands)
```

## Changes

- **`models.py`**: Added `DISPUTED`/`RE_RESOLVED` to MarketStatus, dispute Pydantic models
- **`api.py`**: 3 new endpoints, dispute storage methods, payout reversal logic, dispute constants
- **`migrations/005_add_disputes.sql`**: `disputes` + `dispute_votes` tables, `dispute_window_ends` column
- **`test_disputes.py`**: 16 tests covering full lifecycle (all pass ✅)
- Existing 22 reputation tests still pass ✅

## Design Decisions

- **Top N by volume** for voter eligibility — skin in the game matters more than account count
- **Payout reversal** on flip: old winners get clawed back, new winners get paid
- **Single round**: keeps it simple, prevents infinite dispute loops
- **24h window**: enough time for traders to notice, short enough to finalize quickly

Closes #8