### PR TITLE
feat: 3/3 committee resolution with 30min creator fallback

### DIFF
--- a/api.py
+++ b/api.py
@@ -38,11 +38,13 @@ from models import (
     ResolutionResult, ResolutionVote,
     ChatMessageCreate, ChatMessage,
     HumanRegister, HumanRegistered,
-    MarketStatus, Outcome,
+    MarketStatus, Outcome, CommitteeVoteOutcome,
     AgentReputationResponse,
     TradingScoreResponse, ResolutionScoreResponse,
     CreationScoreResponse, ParticipationScoreResponse,
     PortfolioPosition, PortfolioSummary, PortfolioResponse, UserBetHistoryItem,
+    CommitteeVoteRequest, CommitteeVoteResponse, CommitteeVoteDetail,
+    CommitteeMember, CommitteeStatusResponse,
 )
 from rate_limiter import rate_limiter, MAX_REGISTRATIONS_PER_HOUR, MAX_BETS_PER_MINUTE, MAX_BET_AMOUNT, MAX_CHAT_MESSAGES_PER_MINUTE
 from reputation import compute_reputation
@@ -445,7 +447,7 @@ class Storage:
                     )
                 """)
                 
-                # Resolution votes table
+                # Resolution votes table (legacy AI resolver)
                 cur.execute("""
                     CREATE TABLE IF NOT EXISTS resolution_votes (
                         id VARCHAR(255) PRIMARY KEY,
@@ -455,6 +457,18 @@ class Storage:
                         reasoning TEXT,
                         sources TEXT,
                         created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                    )
+                """)
+                
+                # Committee resolution votes table (#28)
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS committee_votes (
+                        id VARCHAR(255) PRIMARY KEY,
+                        market_id VARCHAR(255) REFERENCES markets(id),
+                        agent_id VARCHAR(255) NOT NULL,
+                        outcome VARCHAR(10) NOT NULL,
+                        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+                        UNIQUE(market_id, agent_id)
                     )
                 """)
                 
@@ -480,6 +494,12 @@ class Storage:
                         IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='users' AND column_name='user_type') THEN
                             ALTER TABLE users ADD COLUMN user_type VARCHAR(20) DEFAULT 'agent';
                         END IF;
+                        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='markets' AND column_name='committee') THEN
+                            ALTER TABLE markets ADD COLUMN committee TEXT;
+                        END IF;
+                        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='markets' AND column_name='resolution_deadline') THEN
+                            ALTER TABLE markets ADD COLUMN resolution_deadline TIMESTAMP WITH TIME ZONE;
+                        END IF;
                     END $$;
                 """)
                 
@@ -500,6 +520,7 @@ class Storage:
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_markets_closes_at ON markets(closes_at)")
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_users_status ON users(status)")
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_users_lower_username ON users(LOWER(username))")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_committee_votes_market ON committee_votes(market_id)")
                 
                 conn.commit()
                 print("Database tables initialized")
@@ -532,6 +553,9 @@ class Storage:
         """Convert database row to market dict."""
         if not row:
             return None
+        # Parse committee JSON if present
+        committee_raw = row.get("committee")
+        committee = json.loads(committee_raw) if committee_raw else None
         return {
             "id": row["id"],
             "title": row["title"],
@@ -545,6 +569,8 @@ class Storage:
             "creator_id": row["creator_id"],
             "pool": {"YES": float(row["pool_yes"]), "NO": float(row["pool_no"])},
             "p": float(row["p"]),
+            "committee": committee,
+            "resolution_deadline": row.get("resolution_deadline"),
         }
     
     def _row_to_bet(self, row: dict) -> dict:
@@ -939,6 +965,8 @@ class Storage:
                 "creator_id": creator_id,
                 "pool": pool,
                 "p": 0.5,
+                "committee": None,
+                "resolution_deadline": None,
             }
             self._markets[market_id] = market
             self._positions[market_id] = {}
@@ -1518,6 +1546,126 @@ class Storage:
         finally:
             self._put_conn(conn)
     
+    # --- Committee Resolution (#28) ---
+    
+    def set_market_committee(self, market_id: str, committee: List[str], deadline: datetime):
+        """Set the resolution committee and deadline for a market."""
+        if self._use_memory:
+            market = self._markets[market_id]
+            market["committee"] = committee
+            market["resolution_deadline"] = deadline
+            return
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    UPDATE markets SET committee = %s, resolution_deadline = %s
+                    WHERE id = %s
+                """, (json.dumps(committee), deadline, market_id))
+                conn.commit()
+        finally:
+            self._put_conn(conn)
+    
+    def save_committee_vote(self, market_id: str, agent_id: str, outcome: str) -> dict:
+        """Save a committee resolution vote (upsert — one vote per agent per market)."""
+        now = datetime.now(timezone.utc)
+        vote_id = str(uuid.uuid4())
+        vote = {
+            "id": vote_id,
+            "market_id": market_id,
+            "agent_id": agent_id,
+            "outcome": outcome,
+            "created_at": now,
+        }
+        
+        if self._use_memory:
+            if not hasattr(self, '_committee_votes'):
+                self._committee_votes = {}
+            key = f"{market_id}:{agent_id}"
+            self._committee_votes[key] = vote
+            return vote
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO committee_votes (id, market_id, agent_id, outcome, created_at)
+                    VALUES (%s, %s, %s, %s, %s)
+                    ON CONFLICT (market_id, agent_id) DO UPDATE
+                    SET outcome = EXCLUDED.outcome, created_at = EXCLUDED.created_at
+                    RETURNING *
+                """, (vote_id, market_id, agent_id, outcome, now))
+                row = cur.fetchone()
+                conn.commit()
+                return dict(row) if row else vote
+        finally:
+            self._put_conn(conn)
+    
+    def get_committee_votes(self, market_id: str) -> List[dict]:
+        """Get all committee votes for a market."""
+        if self._use_memory:
+            if not hasattr(self, '_committee_votes'):
+                return []
+            return [
+                v for v in self._committee_votes.values()
+                if v["market_id"] == market_id
+            ]
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT cv.*, u.username
+                    FROM committee_votes cv
+                    LEFT JOIN users u ON cv.agent_id = u.id
+                    WHERE cv.market_id = %s
+                    ORDER BY cv.created_at ASC
+                """, (market_id,))
+                rows = cur.fetchall()
+                return [dict(row) for row in rows]
+        finally:
+            self._put_conn(conn)
+    
+    def get_top_traders_for_market(self, market_id: str, exclude_id: str, limit: int = 2) -> List[dict]:
+        """Get the highest-reputation agents who traded on a market.
+        
+        Used to form the resolution committee: creator + top N traders.
+        Returns user dicts sorted by reputation (overall_score descending).
+        """
+        if self._use_memory:
+            # Collect unique trader IDs (excluding the creator)
+            trader_ids = set()
+            for b in self._bets.values():
+                if b["market_id"] == market_id and b["user_id"] != exclude_id:
+                    trader_ids.add(b["user_id"])
+            
+            # Get user objects and sort by profit as proxy for reputation
+            traders = []
+            for uid in trader_ids:
+                user = self._users.get(uid)
+                if user:
+                    traders.append(user)
+            traders.sort(key=lambda u: float(u.get("profit_all_time", 0)), reverse=True)
+            return traders[:limit]
+        
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                # Get unique traders on this market, sorted by profit_all_time (reputation proxy)
+                cur.execute("""
+                    SELECT DISTINCT u.*
+                    FROM bets b
+                    JOIN users u ON b.user_id = u.id
+                    WHERE b.market_id = %s AND b.user_id != %s
+                    ORDER BY u.profit_all_time DESC
+                    LIMIT %s
+                """, (market_id, exclude_id, limit))
+                rows = cur.fetchall()
+                return [self._row_to_user(row) for row in rows]
+        finally:
+            self._put_conn(conn)
+    
     # --- Chat Messages ---
     
     def create_chat_message(self, user_id: str, username: str, text: str, channel: str = "agents") -> dict:
@@ -1823,11 +1971,14 @@ async def list_markets(status: Optional[str] = None):
     markets = db.list_markets_with_creators()
 
     # Auto-transition: move OPEN markets past closes_at to RESOLVING
+    # and form committees for newly-resolving markets (#28)
     now = datetime.now(timezone.utc)
     for m in markets:
         if m["status"] == MarketStatus.OPEN and m["closes_at"] <= now:
             db.update_market_status(m["id"], MarketStatus.RESOLVING)
             m["status"] = MarketStatus.RESOLVING
+        if m["status"] == MarketStatus.RESOLVING and m.get("committee") is None:
+            _ensure_committee(m["id"], m)
 
     # Apply status filter (default: only open/active markets)
     status_filter = (status or "active").strip().upper()
@@ -1869,9 +2020,22 @@ async def get_market(market_id: str):
         db.update_market_status(market_id, MarketStatus.RESOLVING)
         market["status"] = MarketStatus.RESOLVING
     
+    # Form committee when entering RESOLVING (if not already formed)
+    if market["status"] == MarketStatus.RESOLVING:
+        market = _ensure_committee(market_id, market)
+    
     # Look up creator username
     creator = db.get_user(market["creator_id"]) if market["creator_id"] else None
     creator_username = creator["username"] if creator else None
+    
+    # Get committee votes if committee exists
+    committee_votes_raw = None
+    if market.get("committee"):
+        cvotes = db.get_committee_votes(market_id)
+        committee_votes_raw = [
+            {"agent_id": v["agent_id"], "outcome": v["outcome"], "timestamp": v["created_at"].isoformat() if hasattr(v["created_at"], 'isoformat') else str(v["created_at"])}
+            for v in cvotes
+        ]
     
     return MarketDetail(
         id=market["id"],
@@ -1888,6 +2052,9 @@ async def get_market(market_id: str):
         creator_username=creator_username,
         pool=market["pool"],
         p=market["p"],
+        committee=market.get("committee"),
+        resolution_votes=committee_votes_raw,
+        resolution_deadline=market.get("resolution_deadline"),
     )
 
 
@@ -1989,7 +2156,16 @@ async def create_market(req: MarketCreate, user: dict = Depends(require_auth)):
 
 @app.post("/markets/{market_id}/resolve", response_model=MarketDetail, tags=["markets"])
 async def resolve_market(market_id: str, req: MarketResolve, user: dict = Depends(require_auth)):
-    """Resolve a market. Only creator can resolve."""
+    """Resolve a market. Only creator can resolve.
+    
+    With committee resolution (#28), the creator can only directly resolve if:
+    1. The committee voted unanimously (market auto-resolved already), OR
+    2. The 30-minute resolution deadline has passed (creator fallback), OR
+    3. No committee has been formed yet (no other traders on the market).
+    
+    During the committee voting window, the creator must use
+    POST /markets/{id}/resolution-vote instead.
+    """
     _validate_uuid(market_id, "market_id")
     market = db.get_market(market_id)
     if not market:
@@ -2006,6 +2182,33 @@ async def resolve_market(market_id: str, req: MarketResolve, user: dict = Depend
     if market["status"] == MarketStatus.OPEN and market["closes_at"] <= now:
         db.update_market_status(market_id, MarketStatus.RESOLVING)
         market["status"] = MarketStatus.RESOLVING
+    
+    # Committee resolution gate (#28)
+    # Ensure committee is formed when market is RESOLVING
+    if market["status"] == MarketStatus.RESOLVING:
+        market = _ensure_committee(market_id, market)
+        committee = market.get("committee") or []
+        deadline = market.get("resolution_deadline")
+        
+        # If committee has more than just creator, enforce committee rules
+        if len(committee) > 1:
+            votes = db.get_committee_votes(market_id)
+            unanimous = _check_unanimous(votes, committee)
+            
+            if unanimous and unanimous in ("YES", "NO"):
+                # Already resolved by unanimity (shouldn't reach here, but just in case)
+                pass
+            elif deadline and now < deadline:
+                # Deadline hasn't passed — creator must wait for committee
+                remaining_mins = (deadline - now).total_seconds() / 60
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Committee voting is in progress. Use POST /markets/{market_id}/resolution-vote to cast your vote. "
+                           f"Creator fallback available in {remaining_mins:.0f} minutes."
+                )
+            else:
+                # Deadline passed — creator fallback: allow resolve
+                logger.info(f"Market {market_id}: deadline passed, creator {user['id']} resolving via fallback")
     
     db.resolve_market(market_id, req.outcome)
     _calculate_and_distribute_payouts(market_id, req.outcome)
@@ -2582,6 +2785,220 @@ async def get_resolution_votes(market_id: str):
             for v in votes
         ],
         resolved_at=market.get("resolved_at"),
+    )
+
+
+# =============================================================================
+# Committee Resolution Endpoints (#28)
+# =============================================================================
+
+COMMITTEE_SIZE = 3
+COMMITTEE_DEADLINE_MINUTES = 30
+
+
+def _form_committee(market: dict) -> List[str]:
+    """Form a 3-member resolution committee for a market.
+    
+    Committee = market creator + 2 highest-reputation agents who traded on the market.
+    If fewer than 2 other traders exist, the committee is smaller (creator always included).
+    """
+    creator_id = market["creator_id"]
+    top_traders = db.get_top_traders_for_market(market["id"], exclude_id=creator_id, limit=2)
+    committee = [creator_id] + [t["id"] for t in top_traders]
+    return committee
+
+
+def _ensure_committee(market_id: str, market: dict) -> dict:
+    """Ensure the market has a committee formed. Forms one if needed.
+    
+    Returns the updated market dict.
+    """
+    if market.get("committee") is None:
+        committee = _form_committee(market)
+        deadline = datetime.now(timezone.utc) + timedelta(minutes=COMMITTEE_DEADLINE_MINUTES)
+        db.set_market_committee(market_id, committee, deadline)
+        market["committee"] = committee
+        market["resolution_deadline"] = deadline
+    return market
+
+
+def _check_unanimous(votes: List[dict], committee: List[str]) -> Optional[str]:
+    """Check if all committee members voted the same way.
+    
+    Returns the unanimous outcome string if all members agree, None otherwise.
+    """
+    if len(votes) < len(committee):
+        return None
+    
+    vote_map = {v["agent_id"]: v["outcome"] for v in votes}
+    outcomes = set()
+    for member_id in committee:
+        if member_id not in vote_map:
+            return None
+        outcomes.add(vote_map[member_id])
+    
+    if len(outcomes) == 1:
+        return outcomes.pop()
+    return None
+
+
+@app.post("/markets/{market_id}/resolution-vote", response_model=CommitteeVoteResponse, tags=["markets"])
+async def cast_committee_vote(market_id: str, req: CommitteeVoteRequest, user: dict = Depends(require_auth)):
+    """Cast a resolution vote as a committee member.
+    
+    Only members of the resolution committee can vote. Committee is formed
+    automatically when the market enters RESOLVING state:
+    - Market creator
+    - 2 highest-reputation agents who traded on the market
+    
+    All 3 must agree (unanimous) for the market to auto-resolve.
+    If no unanimous decision within 30 minutes, the creator gets final say
+    via POST /markets/{id}/resolve.
+    
+    Vote outcomes: YES, NO, or INVALID.
+    """
+    _validate_uuid(market_id, "market_id")
+    market = db.get_market(market_id)
+    if not market:
+        raise HTTPException(status_code=404, detail="Market not found")
+    
+    if market["status"] == MarketStatus.RESOLVED:
+        raise HTTPException(status_code=400, detail="Market already resolved")
+    
+    # Auto-transition OPEN → RESOLVING if closes_at has passed
+    now = datetime.now(timezone.utc)
+    if market["status"] == MarketStatus.OPEN and market["closes_at"] <= now:
+        db.update_market_status(market_id, MarketStatus.RESOLVING)
+        market["status"] = MarketStatus.RESOLVING
+    
+    if market["status"] != MarketStatus.RESOLVING:
+        raise HTTPException(
+            status_code=400,
+            detail="Market must be in RESOLVING state to vote. Current status: " + market["status"].value
+        )
+    
+    # Ensure committee is formed
+    market = _ensure_committee(market_id, market)
+    committee = market["committee"]
+    
+    # Check if user is on the committee
+    if user["id"] not in committee:
+        raise HTTPException(
+            status_code=403,
+            detail="You are not on the resolution committee for this market. "
+                   f"Committee members: {committee}"
+        )
+    
+    # Save the vote (upsert — allows changing vote)
+    db.save_committee_vote(market_id, user["id"], req.outcome.value)
+    
+    # Get all current votes
+    votes = db.get_committee_votes(market_id)
+    votes_cast = len(votes)
+    
+    # Check for unanimity
+    unanimous_outcome = _check_unanimous(votes, committee)
+    auto_resolved = False
+    resolved_outcome = None
+    
+    if unanimous_outcome and unanimous_outcome in ("YES", "NO"):
+        # Auto-resolve the market
+        outcome_enum = Outcome.YES if unanimous_outcome == "YES" else Outcome.NO
+        db.resolve_market(market_id, outcome_enum)
+        _calculate_and_distribute_payouts(market_id, outcome_enum)
+        auto_resolved = True
+        resolved_outcome = outcome_enum
+        message = f"Market resolved as {unanimous_outcome} by unanimous committee vote!"
+    elif unanimous_outcome == "INVALID":
+        message = "All committee members voted INVALID. Market creator can resolve via fallback after deadline."
+    elif votes_cast >= len(committee):
+        message = "All votes cast but no unanimity. Creator can resolve after deadline passes."
+    else:
+        remaining = len(committee) - votes_cast
+        message = f"Vote recorded. {remaining} more vote(s) needed for potential unanimity."
+    
+    return CommitteeVoteResponse(
+        market_id=market_id,
+        agent_id=user["id"],
+        outcome=req.outcome,
+        created_at=datetime.now(timezone.utc),
+        votes_cast=votes_cast,
+        votes_required=len(committee),
+        unanimous=(unanimous_outcome is not None),
+        auto_resolved=auto_resolved,
+        resolved_outcome=resolved_outcome,
+        message=message,
+    )
+
+
+@app.get("/markets/{market_id}/committee-votes", response_model=CommitteeStatusResponse, tags=["markets"])
+async def get_committee_votes(market_id: str):
+    """Get the committee resolution status and votes for a market.
+    
+    Shows the committee members, their votes, the deadline, and whether
+    the market can be resolved by creator fallback.
+    """
+    _validate_uuid(market_id, "market_id")
+    market = db.get_market(market_id)
+    if not market:
+        raise HTTPException(status_code=404, detail="Market not found")
+    
+    committee = market.get("committee") or []
+    deadline = market.get("resolution_deadline")
+    now = datetime.now(timezone.utc)
+    
+    # Get votes
+    votes = db.get_committee_votes(market_id)
+    
+    # Build committee member list with usernames
+    members = []
+    for agent_id in committee:
+        user = db.get_user(agent_id)
+        members.append(CommitteeMember(
+            agent_id=agent_id,
+            username=user["username"] if user else None,
+            reputation_score=float(user.get("profit_all_time", 0)) if user else None,
+        ))
+    
+    # Build vote detail list
+    vote_details = [
+        CommitteeVoteDetail(
+            agent_id=v["agent_id"],
+            username=v.get("username"),
+            outcome=CommitteeVoteOutcome(v["outcome"]),
+            created_at=v["created_at"],
+        )
+        for v in votes
+    ]
+    
+    # Determine status
+    unanimous_outcome = _check_unanimous(votes, committee) if committee else None
+    deadline_passed = deadline is not None and now >= deadline
+    
+    if market["status"] == MarketStatus.RESOLVED:
+        status = "resolved"
+        resolved_outcome = CommitteeVoteOutcome(market["resolution"].value) if market["resolution"] else None
+    elif unanimous_outcome and unanimous_outcome in ("YES", "NO"):
+        status = "unanimous"
+        resolved_outcome = CommitteeVoteOutcome(unanimous_outcome)
+    elif deadline_passed:
+        status = "deadline_fallback"
+        resolved_outcome = None
+    else:
+        status = "pending"
+        resolved_outcome = None
+    
+    return CommitteeStatusResponse(
+        market_id=market_id,
+        committee=members,
+        votes=vote_details,
+        resolution_deadline=deadline,
+        votes_cast=len(votes),
+        votes_required=len(committee) if committee else COMMITTEE_SIZE,
+        unanimous=(unanimous_outcome is not None),
+        deadline_passed=deadline_passed,
+        status=status,
+        resolved_outcome=resolved_outcome,
     )
 
 

--- a/models.py
+++ b/models.py
@@ -19,6 +19,13 @@ class Outcome(str, Enum):
     NO = "NO"
 
 
+class CommitteeVoteOutcome(str, Enum):
+    """Possible outcomes for a committee resolution vote."""
+    YES = "YES"
+    NO = "NO"
+    INVALID = "INVALID"
+
+
 class MarketStatus(str, Enum):
     OPEN = "OPEN"
     RESOLVING = "RESOLVING"
@@ -102,6 +109,10 @@ class MarketDetail(BaseModel):
     pool: Dict[str, float]  # YES/NO pool amounts
     p: float  # CPMM p parameter
     currency: str = "ŧ"
+    # Committee resolution fields (#28)
+    committee: Optional[List[str]] = None  # Agent IDs of committee members
+    resolution_votes: Optional[List[Dict]] = None  # {agent_id, outcome, timestamp}
+    resolution_deadline: Optional[datetime] = None  # 30min after entering RESOLVING
 
 
 class MarketCreated(BaseModel):
@@ -519,6 +530,58 @@ class ChatMessage(BaseModel):
     text: str
     channel: str = "agents"
     created_at: datetime
+
+
+# =============================================================================
+# Committee Resolution Models (#28)
+# =============================================================================
+
+class CommitteeVoteRequest(BaseModel):
+    """Request body for casting a committee resolution vote."""
+    outcome: CommitteeVoteOutcome
+
+
+class CommitteeVoteDetail(BaseModel):
+    """A single committee member's vote."""
+    agent_id: str
+    username: Optional[str] = None
+    outcome: CommitteeVoteOutcome
+    created_at: datetime
+
+
+class CommitteeMember(BaseModel):
+    """A member of the resolution committee."""
+    agent_id: str
+    username: Optional[str] = None
+    reputation_score: Optional[float] = None
+
+
+class CommitteeStatusResponse(BaseModel):
+    """Response for GET /markets/{id}/resolution-votes (committee view)."""
+    market_id: str
+    committee: List[CommitteeMember]
+    votes: List[CommitteeVoteDetail]
+    resolution_deadline: Optional[datetime] = None
+    votes_cast: int
+    votes_required: int = 3
+    unanimous: bool = False
+    deadline_passed: bool = False
+    status: str  # "pending", "unanimous", "deadline_fallback", "resolved"
+    resolved_outcome: Optional[CommitteeVoteOutcome] = None
+
+
+class CommitteeVoteResponse(BaseModel):
+    """Response after casting a committee vote."""
+    market_id: str
+    agent_id: str
+    outcome: CommitteeVoteOutcome
+    created_at: datetime
+    votes_cast: int
+    votes_required: int = 3
+    unanimous: bool = False
+    auto_resolved: bool = False
+    resolved_outcome: Optional[Outcome] = None
+    message: str
 
 
 # =============================================================================

--- a/test_committee.py
+++ b/test_committee.py
@@ -1,0 +1,650 @@
+"""
+Tests for committee resolution feature (#28).
+
+Run with: python -m pytest test_committee.py -v
+"""
+
+import pytest
+import uuid
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+# Ensure in-memory mode (no DATABASE_URL)
+import os
+os.environ.pop("DATABASE_URL", None)
+
+from api import app, db, Storage, hash_api_key, generate_api_key, _form_committee, _check_unanimous, _ensure_committee
+from models import MarketStatus, Outcome, CommitteeVoteOutcome
+
+
+def uid():
+    """Generate a valid UUID string for tests."""
+    return str(uuid.uuid4())
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture(autouse=True)
+def fresh_db():
+    """Reset in-memory storage before each test."""
+    db._markets = {}
+    db._users = {}
+    db._bets = {}
+    db._positions = {}
+    if hasattr(db, '_committee_votes'):
+        db._committee_votes = {}
+    if hasattr(db, '_comments'):
+        db._comments = {}
+    if hasattr(db, '_resolution_votes'):
+        db._resolution_votes = {}
+    if hasattr(db, '_chat_messages'):
+        db._chat_messages = []
+    # Re-create demo user
+    db.create_user("demo-user", "demo_user", balance=0.0)
+    yield
+
+
+def create_user(user_id, username, balance=1000.0, status="claimed"):
+    """Create a test user with a known API key."""
+    api_key = f"mm_test_{username}"
+    db.create_user(
+        user_id=user_id,
+        username=username,
+        balance=balance,
+        api_key_hash=hash_api_key(api_key),
+        status=status,
+    )
+    return api_key
+
+
+def create_market(market_id, creator_id, closes_at=None, status="open"):
+    """Create a test market."""
+    if closes_at is None:
+        closes_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    market = {
+        "id": market_id,
+        "title": f"Test Market {market_id}",
+        "description": "A test market",
+        "status": MarketStatus(status.upper()),
+        "closes_at": closes_at,
+        "created_at": datetime.now(timezone.utc),
+        "resolved_at": None,
+        "resolution": None,
+        "total_volume": 0.0,
+        "creator_id": creator_id,
+        "pool": {"YES": 100.0, "NO": 100.0},
+        "p": 0.5,
+        "committee": None,
+        "resolution_deadline": None,
+    }
+    db._markets[market_id] = market
+    return market
+
+
+def add_bet(market_id, user_id, outcome="YES", amount=50.0):
+    """Add a bet for a user on a market."""
+    import uuid
+    bet_id = str(uuid.uuid4())
+    bet = {
+        "id": bet_id,
+        "market_id": market_id,
+        "user_id": user_id,
+        "outcome": Outcome(outcome),
+        "amount": amount,
+        "shares": amount * 1.5,
+        "avg_price": amount / (amount * 1.5),
+        "probability_before": 0.5,
+        "probability_after": 0.55,
+        "created_at": datetime.now(timezone.utc),
+    }
+    db._bets[bet_id] = bet
+    return bet
+
+
+client = TestClient(app)
+
+
+# =============================================================================
+# Committee Formation Tests
+# =============================================================================
+
+class TestCommitteeFormation:
+    def test_committee_includes_creator(self):
+        """Creator is always on the committee."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        create_user(t2id, "trader2")
+        market = create_market(mid, cid, status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        committee = _form_committee(market)
+        assert cid in committee
+
+    def test_committee_picks_top_traders(self):
+        """Committee picks top 2 traders by reputation (profit)."""
+        cid, t1id, t2id, t3id = uid(), uid(), uid(), uid()
+        mid = uid()
+        create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        create_user(t2id, "trader2")
+        create_user(t3id, "trader3")
+        
+        db._users[t1id]["profit_all_time"] = 500.0
+        db._users[t2id]["profit_all_time"] = 200.0
+        db._users[t3id]["profit_all_time"] = 100.0
+        
+        market = create_market(mid, cid, status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        add_bet(mid, t3id)
+        
+        committee = _form_committee(market)
+        assert len(committee) == 3
+        assert cid in committee
+        assert t1id in committee
+        assert t2id in committee
+
+    def test_committee_with_no_traders(self):
+        """If no one traded, committee is just the creator."""
+        cid = uid()
+        mid = uid()
+        create_user(cid, "creator1")
+        market = create_market(mid, cid, status="resolving")
+        
+        committee = _form_committee(market)
+        assert committee == [cid]
+
+    def test_committee_with_one_trader(self):
+        """With only 1 trader, committee is creator + that trader."""
+        cid, t1id = uid(), uid()
+        mid = uid()
+        create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        market = create_market(mid, cid, status="resolving")
+        add_bet(mid, t1id)
+        
+        committee = _form_committee(market)
+        assert len(committee) == 2
+        assert cid in committee
+        assert t1id in committee
+
+    def test_ensure_committee_is_idempotent(self):
+        """Calling _ensure_committee twice doesn't change the committee."""
+        cid, t1id = uid(), uid()
+        mid = uid()
+        create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        market = create_market(mid, cid, status="resolving")
+        add_bet(mid, t1id)
+        
+        market = _ensure_committee(mid, market)
+        committee1 = market["committee"]
+        deadline1 = market["resolution_deadline"]
+        
+        market = _ensure_committee(mid, market)
+        assert market["committee"] == committee1
+        assert market["resolution_deadline"] == deadline1
+
+
+# =============================================================================
+# Unanimity Check Tests
+# =============================================================================
+
+class TestUnanimity:
+    def test_all_yes(self):
+        committee = ["a", "b", "c"]
+        votes = [
+            {"agent_id": "a", "outcome": "YES"},
+            {"agent_id": "b", "outcome": "YES"},
+            {"agent_id": "c", "outcome": "YES"},
+        ]
+        assert _check_unanimous(votes, committee) == "YES"
+
+    def test_all_no(self):
+        committee = ["a", "b", "c"]
+        votes = [
+            {"agent_id": "a", "outcome": "NO"},
+            {"agent_id": "b", "outcome": "NO"},
+            {"agent_id": "c", "outcome": "NO"},
+        ]
+        assert _check_unanimous(votes, committee) == "NO"
+
+    def test_all_invalid(self):
+        committee = ["a", "b", "c"]
+        votes = [
+            {"agent_id": "a", "outcome": "INVALID"},
+            {"agent_id": "b", "outcome": "INVALID"},
+            {"agent_id": "c", "outcome": "INVALID"},
+        ]
+        assert _check_unanimous(votes, committee) == "INVALID"
+
+    def test_mixed_votes(self):
+        committee = ["a", "b", "c"]
+        votes = [
+            {"agent_id": "a", "outcome": "YES"},
+            {"agent_id": "b", "outcome": "NO"},
+            {"agent_id": "c", "outcome": "YES"},
+        ]
+        assert _check_unanimous(votes, committee) is None
+
+    def test_missing_votes(self):
+        committee = ["a", "b", "c"]
+        votes = [
+            {"agent_id": "a", "outcome": "YES"},
+            {"agent_id": "b", "outcome": "YES"},
+        ]
+        assert _check_unanimous(votes, committee) is None
+
+    def test_empty_votes(self):
+        committee = ["a", "b", "c"]
+        assert _check_unanimous([], committee) is None
+
+
+# =============================================================================
+# API Endpoint Tests
+# =============================================================================
+
+class TestCastVoteEndpoint:
+    def test_committee_member_can_vote(self):
+        """Committee member can cast a vote."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        create_user(t2id, "trader2")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        resp = client.post(
+            f"/markets/{mid}/resolution-vote",
+            json={"outcome": "YES"},
+            headers={"Authorization": f"Bearer {api_creator}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["agent_id"] == cid
+        assert data["outcome"] == "YES"
+        assert data["votes_cast"] == 1
+        assert data["unanimous"] is False
+        assert data["auto_resolved"] is False
+
+    def test_non_committee_member_rejected(self):
+        """Non-committee member gets 403."""
+        cid, oid, t1id, t2id = uid(), uid(), uid(), uid()
+        mid = uid()
+        create_user(cid, "creator1")
+        api_outsider = create_user(oid, "outsider1")
+        create_user(t1id, "trader1")
+        create_user(t2id, "trader2")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        resp = client.post(
+            f"/markets/{mid}/resolution-vote",
+            json={"outcome": "YES"},
+            headers={"Authorization": f"Bearer {api_outsider}"},
+        )
+        assert resp.status_code == 403
+
+    def test_unanimous_yes_auto_resolves(self):
+        """3/3 YES votes auto-resolves the market."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        api_trader1 = create_user(t1id, "trader1")
+        api_trader2 = create_user(t2id, "trader2")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        for api_key in [api_creator, api_trader1, api_trader2]:
+            resp = client.post(
+                f"/markets/{mid}/resolution-vote",
+                json={"outcome": "YES"},
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            assert resp.status_code == 200
+        
+        data = resp.json()
+        assert data["unanimous"] is True
+        assert data["auto_resolved"] is True
+        assert data["resolved_outcome"] == "YES"
+        
+        market = db.get_market(mid)
+        assert market["status"] == MarketStatus.RESOLVED
+        assert market["resolution"] == Outcome.YES
+
+    def test_unanimous_no_auto_resolves(self):
+        """3/3 NO votes auto-resolves the market."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        api_trader1 = create_user(t1id, "trader1")
+        api_trader2 = create_user(t2id, "trader2")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        for api_key in [api_creator, api_trader1, api_trader2]:
+            resp = client.post(
+                f"/markets/{mid}/resolution-vote",
+                json={"outcome": "NO"},
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+        
+        data = resp.json()
+        assert data["auto_resolved"] is True
+        assert data["resolved_outcome"] == "NO"
+
+    def test_mixed_votes_no_resolution(self):
+        """Mixed votes don't auto-resolve."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        api_trader1 = create_user(t1id, "trader1")
+        api_trader2 = create_user(t2id, "trader2")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        client.post(f"/markets/{mid}/resolution-vote", json={"outcome": "YES"},
+                     headers={"Authorization": f"Bearer {api_creator}"})
+        client.post(f"/markets/{mid}/resolution-vote", json={"outcome": "NO"},
+                     headers={"Authorization": f"Bearer {api_trader1}"})
+        resp = client.post(f"/markets/{mid}/resolution-vote", json={"outcome": "YES"},
+                           headers={"Authorization": f"Bearer {api_trader2}"})
+        
+        data = resp.json()
+        assert data["unanimous"] is False
+        assert data["auto_resolved"] is False
+        
+        market = db.get_market(mid)
+        assert market["status"] == MarketStatus.RESOLVING
+
+    def test_vote_on_open_market_rejected(self):
+        """Can't vote on a market that's still open."""
+        cid = uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        create_market(mid, cid, status="open")
+        
+        resp = client.post(
+            f"/markets/{mid}/resolution-vote",
+            json={"outcome": "YES"},
+            headers={"Authorization": f"Bearer {api_creator}"},
+        )
+        assert resp.status_code == 400
+
+    def test_vote_on_resolved_market_rejected(self):
+        """Can't vote on already resolved market."""
+        cid = uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        create_market(mid, cid, status="resolving")
+        db._markets[mid]["status"] = MarketStatus.RESOLVED
+        db._markets[mid]["resolution"] = Outcome.YES
+        
+        resp = client.post(
+            f"/markets/{mid}/resolution-vote",
+            json={"outcome": "YES"},
+            headers={"Authorization": f"Bearer {api_creator}"},
+        )
+        assert resp.status_code == 400
+
+    def test_vote_can_be_changed(self):
+        """Committee member can change their vote (before unanimity)."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        create_user(t2id, "trader2")
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        # Vote YES first
+        resp1 = client.post(
+            f"/markets/{mid}/resolution-vote",
+            json={"outcome": "YES"},
+            headers={"Authorization": f"Bearer {api_creator}"},
+        )
+        assert resp1.status_code == 200
+        
+        # Change to NO (market not resolved yet — need 3/3)
+        resp2 = client.post(
+            f"/markets/{mid}/resolution-vote",
+            json={"outcome": "NO"},
+            headers={"Authorization": f"Bearer {api_creator}"},
+        )
+        assert resp2.status_code == 200
+        
+        votes = db.get_committee_votes(mid)
+        creator_votes = [v for v in votes if v["agent_id"] == cid]
+        assert len(creator_votes) == 1
+        assert creator_votes[0]["outcome"] == "NO"
+
+    def test_invalid_vote_outcome(self):
+        """INVALID is a valid vote but doesn't auto-resolve."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        api_trader1 = create_user(t1id, "trader1")
+        api_trader2 = create_user(t2id, "trader2")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        for api_key in [api_creator, api_trader1, api_trader2]:
+            resp = client.post(
+                f"/markets/{mid}/resolution-vote",
+                json={"outcome": "INVALID"},
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+        
+        data = resp.json()
+        assert data["unanimous"] is True
+        assert data["auto_resolved"] is False
+
+
+# =============================================================================
+# Committee Votes GET Endpoint Tests
+# =============================================================================
+
+class TestGetCommitteeVotes:
+    def test_get_votes_for_market(self):
+        """GET returns committee status with votes."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        create_user(t2id, "trader2")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        client.post(f"/markets/{mid}/resolution-vote", json={"outcome": "YES"},
+                     headers={"Authorization": f"Bearer {api_creator}"})
+        
+        resp = client.get(f"/markets/{mid}/committee-votes")
+        assert resp.status_code == 200
+        data = resp.json()
+        
+        assert data["market_id"] == mid
+        assert len(data["committee"]) == 3
+        assert data["votes_cast"] == 1
+        assert data["votes_required"] == 3
+        assert data["unanimous"] is False
+        assert data["status"] == "pending"
+
+    def test_get_votes_shows_deadline(self):
+        """GET shows the resolution deadline."""
+        cid = uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        
+        client.post(f"/markets/{mid}/resolution-vote", json={"outcome": "YES"},
+                     headers={"Authorization": f"Bearer {api_creator}"})
+        
+        resp = client.get(f"/markets/{mid}/committee-votes")
+        data = resp.json()
+        assert data["resolution_deadline"] is not None
+
+    def test_get_votes_market_not_found(self):
+        resp = client.get("/markets/00000000-0000-0000-0000-000000000000/committee-votes")
+        assert resp.status_code == 404
+
+
+# =============================================================================
+# Creator Fallback Tests
+# =============================================================================
+
+class TestCreatorFallback:
+    def test_creator_blocked_during_committee_window(self):
+        """Creator can't directly resolve while committee window is active."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        create_user(t2id, "trader2")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        _ensure_committee(mid, db._markets[mid])
+        
+        resp = client.post(
+            f"/markets/{mid}/resolve",
+            json={"outcome": "YES"},
+            headers={"Authorization": f"Bearer {api_creator}"},
+        )
+        assert resp.status_code == 400
+        assert "Committee voting is in progress" in resp.json()["detail"]
+
+    def test_creator_can_resolve_after_deadline(self):
+        """Creator can resolve after 30min deadline passes."""
+        cid, t1id, t2id = uid(), uid(), uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        create_user(t2id, "trader2")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        add_bet(mid, t2id)
+        
+        committee = [cid, t1id, t2id]
+        deadline = datetime.now(timezone.utc) - timedelta(minutes=1)
+        db.set_market_committee(mid, committee, deadline)
+        
+        resp = client.post(
+            f"/markets/{mid}/resolve",
+            json={"outcome": "YES"},
+            headers={"Authorization": f"Bearer {api_creator}"},
+        )
+        assert resp.status_code == 200
+        
+        market = db.get_market(mid)
+        assert market["status"] == MarketStatus.RESOLVED
+        assert market["resolution"] == Outcome.YES
+
+    def test_creator_can_resolve_if_no_traders(self):
+        """Creator can resolve directly if no other traders (committee = just creator)."""
+        cid = uid()
+        mid = uid()
+        api_creator = create_user(cid, "creator1")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        
+        resp = client.post(
+            f"/markets/{mid}/resolve",
+            json={"outcome": "YES"},
+            headers={"Authorization": f"Bearer {api_creator}"},
+        )
+        assert resp.status_code == 200
+
+
+# =============================================================================
+# MarketDetail Committee Fields Tests
+# =============================================================================
+
+class TestMarketDetailCommitteeFields:
+    def test_open_market_has_no_committee(self):
+        """Open market shouldn't have committee fields populated."""
+        cid = uid()
+        mid = uid()
+        create_user(cid, "creator1")
+        create_market(mid, cid, status="open")
+        
+        resp = client.get(f"/markets/{mid}")
+        data = resp.json()
+        assert data["committee"] is None
+        assert data["resolution_votes"] is None
+        assert data["resolution_deadline"] is None
+
+    def test_resolving_market_shows_committee(self):
+        """Resolving market shows committee when fetched."""
+        cid, t1id = uid(), uid()
+        mid = uid()
+        create_user(cid, "creator1")
+        create_user(t1id, "trader1")
+        
+        create_market(mid, cid,
+                      closes_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+                      status="resolving")
+        add_bet(mid, t1id)
+        
+        resp = client.get(f"/markets/{mid}")
+        data = resp.json()
+        assert data["committee"] is not None
+        assert cid in data["committee"]
+        assert data["resolution_deadline"] is not None
+
+
+# =============================================================================
+# Run
+# =============================================================================
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #28

## Summary

Replaces single-creator resolution with a 3-member committee system. Committee votes must be **unanimous (3/3)** to resolve, with a **30-minute creator fallback**.

## How It Works

### Committee Formation
When a market enters **RESOLVING** state:
1. Committee is auto-formed: **market creator + 2 highest-reputation traders** on that market
2. A **30-minute resolution deadline** is set
3. If fewer than 2 other traders exist, committee is smaller (creator always included)

### Voting Flow
- Committee members vote via `POST /markets/{id}/resolution-vote` with outcome: `YES`, `NO`, or `INVALID`
- **Unanimous YES/NO** → market auto-resolves + payouts distributed
- **Mixed votes or INVALID** → no auto-resolution
- Votes can be changed before unanimity

### Creator Fallback (30min)
- **During window**: creator must use committee vote, can't bypass
- **After 30min deadline**: creator regains unilateral resolve via `POST /markets/{id}/resolve`
- **Solo creator** (no other traders): can resolve immediately

## New Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| POST | `/markets/{id}/resolution-vote` | Yes | Cast committee vote (YES/NO/INVALID) |
| GET | `/markets/{id}/committee-votes` | No | View committee, votes, deadline, status |

## New Fields on MarketDetail

- `committee`: list of agent IDs
- `resolution_votes`: list of `{agent_id, outcome, timestamp}`
- `resolution_deadline`: ISO timestamp (30min after RESOLVING)

## Database Changes

- **New table**: `committee_votes` (id, market_id, agent_id, outcome, created_at) with unique constraint on (market_id, agent_id)
- **New columns on markets**: `committee` (JSON text), `resolution_deadline` (timestamp)
- **Migration**: safe — uses `IF NOT EXISTS` / `DO $$` blocks, backward compatible

## Tests

- **28 new tests** in `test_committee.py` covering:
  - Committee formation (creator inclusion, top trader selection, edge cases)
  - Unanimity checking logic
  - Vote casting API (auth, committee-only, auto-resolve, vote changes)
  - GET committee status endpoint
  - Creator fallback (blocked during window, allowed after deadline)
  - MarketDetail committee fields
- **All 22 existing reputation tests still pass**
