### PR TITLE
fix: repair main CI — cache + pagination + lint

### DIFF
--- a/market_cache.py
+++ b/market_cache.py
@@ -18,7 +18,7 @@ See issue #45 for context.
 import hashlib
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 # Default cache TTL in seconds. Short because markets are live-trading
 # instruments where probability/volume change with every bet.
@@ -83,8 +83,12 @@ class MarketListCache:
 
         return entry
 
-    def set(self, status_filter: str, data: List[Any]) -> dict:
+    def set(self, status_filter: str, data: Any) -> dict:
         """Store a cache entry and compute its ETag.
+
+        Accepts either a plain list or a paginated response object (with a
+        ``.data`` attribute).  The full object is stored so cache hits can
+        return it directly; the ETag is computed from the inner list length.
 
         Returns the entry dict (with etag) so callers can use it
         immediately for response headers.
@@ -108,15 +112,19 @@ class MarketListCache:
         self._generation += 1
         self._last_modified = datetime.now(timezone.utc)
 
-    def _compute_etag(self, data: List[Any], status_filter: str) -> str:
+    def _compute_etag(self, data: Any, status_filter: str) -> str:
         """Compute a weak ETag for the response data.
 
         Uses generation + status_filter + data length as a fast fingerprint.
         We don't hash the full payload (expensive for large lists) — the
         generation counter already guarantees uniqueness after invalidation.
+
+        Handles both plain lists and paginated response objects (with a
+        ``.data`` attribute containing the inner list).
         """
-        # Include generation so ETags change after any mutation
-        fingerprint = f"{self._generation}:{status_filter}:{len(data)}"
+        # Support paginated wrapper objects (PaginatedMarketSummary, etc.)
+        inner = data.data if hasattr(data, "data") else data
+        fingerprint = f"{self._generation}:{status_filter}:{len(inner)}"
         digest = hashlib.md5(fingerprint.encode()).hexdigest()[:16]
         return f'W/"{digest}"'
 

--- a/test_api_flows.py
+++ b/test_api_flows.py
@@ -567,7 +567,11 @@ class TestReadEndpoints:
 
         resp = client.get("/markets?status=all")
         assert resp.status_code == 200
-        assert len(resp.json()) >= 2
+        body = resp.json()
+        # /markets now returns a paginated envelope {data: [...], pagination: {...}}
+        assert "data" in body
+        assert "pagination" in body
+        assert len(body["data"]) >= 2
 
     def test_get_market_detail(self, client):
         creator = _register_agent(client, "detail_creator")
@@ -621,7 +625,10 @@ class TestReadEndpoints:
         _register_agent(client, "lb_agent")
         resp = client.get("/leaderboard")
         assert resp.status_code == 200
-        assert isinstance(resp.json(), list)
+        body = resp.json()
+        # /leaderboard now returns a paginated envelope {data: [...], pagination: {...}}
+        assert "data" in body
+        assert isinstance(body["data"], list)
 
 
 # ===================================================================


### PR DESCRIPTION
## What broke

PR #96 (pagination) changed the /markets and /leaderboard response shape from a plain list to a paginated envelope `{data: [...], pagination: {...}}`, but two places weren't updated:

### 1. `market_cache.py` — `_compute_etag()` crashes on `PaginatedMarketSummary`

`_compute_etag()` called `len(data)` assuming a list, but now receives a `PaginatedMarketSummary` object (no `__len__`). This caused a `TypeError` on every uncached `/markets` request → **500 Internal Server Error**.

**Fix:** Extract `.data` (the inner list) when present before computing length. Also updated type hints from `List[Any]` to `Any` and removed the unused `List` import (F401).

### 2. `test_api_flows.py` — Two tests expect old list response shape

- `test_list_markets`: asserted `len(resp.json()) >= 2` (dict has 2 keys, not 2 markets)
- `test_leaderboard`: asserted `isinstance(resp.json(), list)` (now returns dict)

**Fix:** Unwrap `.data` from the paginated envelope before asserting. Added assertions for the envelope structure too.

## Validation

- ✅ All **143 tests** pass
- ✅ Ruff clean (`--select E,F,W --ignore E501,W291,W292,W293`)

## Note on storage.py

The original report mentioned redundant `import warnings` in storage.py — investigated and confirmed this is **not an issue**: there's only one top-level import at line 12, and the `warnings.warn()` calls at lines 679/868/1099 correctly use it. Ruff agrees (no F811).