### PR TITLE
fix: distribute pool residuals on resolution + retroactive fix endpoint

### DIFF
--- a/deps.py
+++ b/deps.py
@@ -188,10 +188,27 @@ def bg_transition_expired_markets() -> None:
 # ---------------------------------------------------------------------------
 
 def calculate_and_distribute_payouts(market_id: str, outcome) -> int:
-    """Calculate and distribute payouts for a resolved market."""
+    """Calculate and distribute payouts for a resolved market.
+
+    Steps:
+    1. Pay winning shares to each position holder.
+    2. Credit the winning-side pool residual (initial liquidity) to the
+       market creator — this is the AMM liquidity that would otherwise
+       stay locked in the pool forever.
+    3. Zero out the pool so the probability reads 1.0 or 0.0 and no
+       tokens remain stuck.
+    4. Zero out all positions for this market (prevents double-counting
+       in portfolio views).
+
+    Idempotent: if the winning pool is already ≤ 0.001, steps 2-4 are
+    skipped (market was already cleaned up).
+    """
     from models import Outcome
     db = get_db()
+    market = db.get_market(market_id)
     positions = db.get_market_positions(market_id)
+
+    # Step 1: Pay out winning shares to position holders
     paid = 0
     for pos in positions:
         winning_shares = pos["yes_shares"] if outcome == Outcome.YES else pos["no_shares"]
@@ -200,6 +217,35 @@ def calculate_and_distribute_payouts(market_id: str, outcome) -> int:
             db.update_user_balance(pos["user_id"], payout)
             db.update_user_profit(pos["user_id"], payout - pos["total_invested"])
             paid += 1
+
+    # Step 2: Credit pool residual to creator
+    if market:
+        pool = market["pool"]
+        winning_pool = pool["YES"] if outcome == Outcome.YES else pool["NO"]
+
+        if winning_pool > 0.001:
+            db.update_user_balance(market["creator_id"], winning_pool)
+            logger.info(
+                "Pool residual %.4f credited to creator %s for market %s",
+                winning_pool, market["creator_id"], market_id,
+            )
+
+        # Step 3: Set pool to terminal state (probability = 1.0 or 0.0)
+        #   YES resolution → pool_yes=0, pool_no=1 → P = 1.0
+        #   NO  resolution → pool_yes=1, pool_no=0 → P = 0.0
+        if outcome == Outcome.YES:
+            terminal_pool = {"YES": 0.0, "NO": 1.0}
+        else:
+            terminal_pool = {"YES": 1.0, "NO": 0.0}
+        db.update_market_pool(market_id, terminal_pool, market["p"], 0)
+
+    # Step 4: Zero out positions (resolved — no longer relevant)
+    for pos in positions:
+        if pos["yes_shares"] > 0:
+            db.reduce_position(market_id, pos["user_id"], Outcome.YES, pos["yes_shares"])
+        if pos["no_shares"] > 0:
+            db.reduce_position(market_id, pos["user_id"], Outcome.NO, pos["no_shares"])
+
     return paid
 
 

--- a/migrations/006_fix_resolved_pool_residuals.sql
+++ b/migrations/006_fix_resolved_pool_residuals.sql
@@ -1,0 +1,45 @@
+-- Migration 006: Fix resolved market pool residuals
+--
+-- Problem: When markets resolve, the winning-side pool shares (initial
+-- liquidity from market creation) remain locked in the pool forever.
+-- This means:
+--   1. ~1055ŧ in winning shares stuck in resolved market pools
+--   2. Probability reads incorrectly (not 0 or 1) for resolved markets
+--   3. Positions not zeroed after payout (double-counting in portfolios)
+--
+-- This migration is provided for documentation. The actual fix is applied
+-- via the /admin/fix-resolutions endpoint which handles balance credits
+-- and position zeroing atomically.
+--
+-- To see what would change (dry run):
+--   curl -X POST /admin/fix-resolutions?dry_run=true \
+--        -H "X-Admin-Secret: $ADMIN_SECRET"
+--
+-- To apply:
+--   curl -X POST /admin/fix-resolutions?dry_run=false \
+--        -H "X-Admin-Secret: $ADMIN_SECRET"
+--
+-- Manual SQL equivalent (POOL FIX ONLY — does NOT credit balances):
+--
+-- Set terminal pool state for YES-resolved markets:
+-- UPDATE markets
+-- SET pool_yes = 0, pool_no = 1
+-- WHERE UPPER(status) = 'RESOLVED' AND UPPER(resolution) = 'YES'
+--   AND pool_yes > 0.001;
+--
+-- Set terminal pool state for NO-resolved markets:
+-- UPDATE markets
+-- SET pool_yes = 1, pool_no = 0
+-- WHERE UPPER(status) = 'RESOLVED' AND UPPER(resolution) = 'NO'
+--   AND pool_no > 0.001;
+--
+-- Zero out positions for all resolved markets:
+-- UPDATE positions
+-- SET yes_shares = 0, no_shares = 0
+-- WHERE market_id IN (
+--   SELECT id FROM markets WHERE UPPER(status) = 'RESOLVED'
+-- );
+
+-- No-op: this migration is documentation-only.
+-- The fix is applied via the admin API endpoint.
+SELECT 1;

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,5 +1,6 @@
 """
-Admin endpoints — user management, market transitions, key regeneration.
+Admin endpoints — user management, market transitions, key regeneration,
+and retroactive resolution fixes.
 """
 
 import logging
@@ -8,9 +9,11 @@ import secrets
 from fastapi import APIRouter, Header, HTTPException, Request
 
 from auth import generate_api_key, ADMIN_SECRET
+from cpmm import get_cpmm_probability
 from deps import get_db
 from errors import error_response, ErrorCode
 from market_cache import market_cache
+from models import MarketStatus, Outcome
 from rate_limiter import rate_limiter
 from storage import hash_api_key
 
@@ -95,4 +98,155 @@ async def admin_regenerate_api_key(username: str, request: Request, x_admin_secr
         "user_id": user["id"],
         "api_key": new_api_key,
         "warning": "Save this key! It will not be shown again.",
+    }
+
+
+@router.post("/admin/fix-resolutions")
+async def admin_fix_resolutions(
+    request: Request,
+    dry_run: bool = True,
+    x_admin_secret: str = Header(None),
+):
+    """Retroactively fix all resolved markets that still have pool residuals.
+
+    For each RESOLVED market this endpoint will:
+    1. Credit the winning-side pool residual to the market creator.
+    2. Set the pool to its terminal state so probability reads 1.0 or 0.0.
+    3. Zero out all positions (already paid out — prevents double-counting).
+
+    The operation is **idempotent**: markets whose winning pool is already
+    ≤ 0.001ŧ are skipped (already fixed).
+
+    Query params:
+        dry_run (bool): If true (default), report what *would* change without
+                        touching the database.  Set to ``false`` to apply.
+
+    Requires ``X-Admin-Secret`` header.
+    """
+    db = get_db()
+    if not ADMIN_SECRET:
+        return error_response(
+            503,
+            "Admin endpoints disabled — ADMIN_SECRET not configured",
+            ErrorCode.SERVICE_UNAVAILABLE,
+        )
+
+    client_ip = request.client.host if request.client else "unknown"
+    allowed, info = rate_limiter.check(
+        f"admin:{client_ip}", max_requests=5, window_seconds=60,
+    )
+    if not allowed:
+        return error_response(
+            429, f"Admin rate limit exceeded. {info['detail']}", ErrorCode.RATE_LIMITED,
+        )
+
+    if not secrets.compare_digest(x_admin_secret or "", ADMIN_SECRET):
+        return error_response(403, "Invalid admin secret", ErrorCode.FORBIDDEN)
+
+    # Gather all resolved markets
+    all_markets = db.list_markets()
+    resolved = [
+        m for m in all_markets if m["status"] == MarketStatus.RESOLVED
+    ]
+
+    fixes = []
+    total_residual = 0.0
+    creator_payouts: dict[str, float] = {}  # creator_id → total credited
+
+    for market in resolved:
+        mid = market["id"]
+        resolution = market["resolution"]
+        pool = market["pool"]
+
+        if resolution is None:
+            continue  # shouldn't happen, but be safe
+
+        winning_pool = (
+            pool["YES"] if resolution == Outcome.YES else pool["NO"]
+        )
+
+        # Idempotency guard: already fixed if pool residual is negligible
+        if winning_pool <= 0.001:
+            continue
+
+        creator = db.get_user(market["creator_id"])
+        creator_name = creator["username"] if creator else "unknown"
+        prob_before = get_cpmm_probability(pool, market["p"])
+
+        # Determine terminal pool state
+        if resolution == Outcome.YES:
+            terminal_pool = {"YES": 0.0, "NO": 1.0}
+            target_prob = 1.0
+        else:
+            terminal_pool = {"YES": 1.0, "NO": 0.0}
+            target_prob = 0.0
+
+        # Collect position info for zeroing
+        positions = db.get_market_positions(mid)
+        position_count = len(positions)
+
+        fix_record = {
+            "market_id": mid,
+            "title": market["title"],
+            "resolution": resolution.value,
+            "probability_before": round(prob_before, 6),
+            "probability_after": target_prob,
+            "pool_before": {
+                "YES": round(pool["YES"], 4),
+                "NO": round(pool["NO"], 4),
+            },
+            "pool_after": terminal_pool,
+            "winning_pool_residual": round(winning_pool, 4),
+            "creator": creator_name,
+            "creator_id": market["creator_id"],
+            "positions_zeroed": position_count,
+        }
+
+        if not dry_run:
+            # 1. Credit residual to creator
+            db.update_user_balance(market["creator_id"], winning_pool)
+            logger.info(
+                "[fix-resolutions] Credited %.4fŧ to %s for market %s",
+                winning_pool, creator_name, mid,
+            )
+
+            # 2. Set pool to terminal state
+            db.update_market_pool(mid, terminal_pool, market["p"], 0)
+
+            # 3. Zero out positions
+            for pos in positions:
+                if pos["yes_shares"] > 0:
+                    db.reduce_position(mid, pos["user_id"], Outcome.YES, pos["yes_shares"])
+                if pos["no_shares"] > 0:
+                    db.reduce_position(mid, pos["user_id"], Outcome.NO, pos["no_shares"])
+
+            fix_record["applied"] = True
+        else:
+            fix_record["applied"] = False
+
+        fixes.append(fix_record)
+        total_residual += winning_pool
+        creator_payouts[market["creator_id"]] = (
+            creator_payouts.get(market["creator_id"], 0) + winning_pool
+        )
+
+    if not dry_run:
+        market_cache.invalidate()
+
+    # Build creator summary
+    creator_summary = []
+    for cid, amount in sorted(creator_payouts.items(), key=lambda x: -x[1]):
+        creator = db.get_user(cid)
+        creator_summary.append({
+            "creator_id": cid,
+            "username": creator["username"] if creator else "unknown",
+            "total_credited": round(amount, 4),
+        })
+
+    return {
+        "dry_run": dry_run,
+        "markets_fixed": len(fixes),
+        "total_residual_distributed": round(total_residual, 4),
+        "creator_summary": creator_summary,
+        "fixes": fixes,
     }


### PR DESCRIPTION
## Problem

When markets resolve, the winning-side pool shares (initial AMM liquidity from market creation) remain locked in the pool forever. The AMM audit found:

- **1,055.19ŧ** stuck across 15 resolved market pools
- Probability not updated to 0/1 for resolved markets (e.g. shows 0.88 instead of 1.0)
- Positions not zeroed after payout (double-counting in portfolio views)

## Root Cause

`calculate_and_distribute_payouts()` only pays winning shares to position holders, but:
1. Never drains the winning pool (initial liquidity stays locked)
2. Never updates the pool to terminal state (probability stays wrong)
3. Never zeros out positions (stale shares inflate portfolio values)

## Fix (Two Parts)

### 1. Forward Fix (`deps.py`)
`calculate_and_distribute_payouts()` now also:
- Credits the winning pool residual to the market creator (they provided initial liquidity)
- Sets pool to terminal state: YES resolution → `{YES: 0, NO: 1}` (prob=1.0), NO → `{YES: 1, NO: 0}` (prob=0.0)
- Zeros out all positions for the resolved market

### 2. Retroactive Fix (`routes/admin.py` — `POST /admin/fix-resolutions`)
New admin endpoint to clean up the 15 already-resolved markets:
- Scans all RESOLVED markets with winning pool > 0.001ŧ
- Credits residual to creator, fixes pool state, zeros positions
- **Dry run by default** (`?dry_run=true`) — preview before applying
- Idempotent: running twice won't double-pay
- Requires `X-Admin-Secret` header

### Redistribution Summary

| Creator | Markets | Amount |
|---------|---------|--------|
| spotter | 13 | 978.83ŧ |
| bicep | 1 | 40.00ŧ |
| crabby | 1 | 36.36ŧ |
| **Total** | **15** | **1,055.19ŧ** |

## Usage

```bash
# Preview what would change
curl -X POST /admin/fix-resolutions?dry_run=true \
  -H 'X-Admin-Secret: $ADMIN_SECRET'

# Apply the fix
curl -X POST /admin/fix-resolutions?dry_run=false \
  -H 'X-Admin-Secret: $ADMIN_SECRET'
```

## Files Changed
- `deps.py` — Forward fix in `calculate_and_distribute_payouts()`
- `routes/admin.py` — New `/admin/fix-resolutions` endpoint
- `migrations/006_fix_resolved_pool_residuals.sql` — Documentation migration

Closes #22