### PR TITLE
feat: markets remain tradeable until resolution (#115)

### DIFF
--- a/deps.py
+++ b/deps.py
@@ -231,32 +231,21 @@ def check_committee_unanimity(market_id: str, committee: list) -> Optional[str]:
 
 
 def maybe_transition_market(market: dict, market_id: str) -> None:
-    """Transition a single OPEN market to RESOLVING if past closes_at.
+    """No-op: markets no longer auto-transition based on closes_at.
 
-    Also forms the committee when transitioning to RESOLVING.
+    Deprecated since issue #115: markets remain OPEN and tradeable until
+    explicitly resolved via POST /markets/{id}/resolve.  The closes_at
+    field is now display-only ("event end time").
     """
-    from models import MarketStatus
-    db = get_db()
-    if market["status"] != MarketStatus.OPEN:
-        return
-    now = datetime.now(timezone.utc)
-    if market["closes_at"] <= now:
-        db.update_market_status(market_id, MarketStatus.RESOLVING)
-        market["status"] = MarketStatus.RESOLVING
-        # Form committee if not already formed
-        if not market.get("committee"):
-            form_committee(market_id, market)
+    pass
 
 
 def bg_transition_expired_markets() -> None:
-    """Background callback: batch-transition expired markets."""
-    try:
-        db = get_db()
-        count = db.transition_expired_markets()
-        if count:
-            logger.info("Background transition: %d market(s) moved OPEN → RESOLVING", count)
-    except Exception:
-        logger.exception("Background market transition failed")
+    """No-op: markets no longer auto-transition based on closes_at.
+
+    Deprecated since issue #115.
+    """
+    pass
 
 
 # ---------------------------------------------------------------------------

--- a/models.py
+++ b/models.py
@@ -71,10 +71,10 @@ class CommitteeOutcome(str, Enum):
 
 
 class MarketStatus(str, Enum):
-    OPEN = "OPEN"
-    RESOLVING = "RESOLVING"
-    CLOSED = "CLOSED"
-    RESOLVED = "RESOLVED"
+    OPEN = "OPEN"            # Tradeable — accepts bets and sells
+    RESOLVING = "RESOLVING"  # Resolution in progress — trading suspended
+    CLOSED = "CLOSED"        # Deprecated (issue #115) — kept for backward compat
+    RESOLVED = "RESOLVED"    # Final — outcome set, payouts distributed
 
 
 # =============================================================================

--- a/routes/markets.py
+++ b/routes/markets.py
@@ -8,13 +8,13 @@ import uuid
 from datetime import datetime, timezone, timedelta
 from typing import Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Request, Response
+from fastapi import APIRouter, Depends, Request, Response
 
 from auth import require_auth
 from cpmm import get_cpmm_probability
 from deps import (
-    get_db, validate_uuid, clamp_pagination, maybe_transition_market,
-    bg_transition_expired_markets, calculate_and_distribute_payouts,
+    get_db, validate_uuid, clamp_pagination,
+    calculate_and_distribute_payouts,
     set_cache_headers, form_committee, check_committee_unanimity,
     MARKET_CREATION_COST, COMMITTEE_WINDOW_MINUTES,
     CABAL_USERNAMES, CABAL_COOLDOWN_MINUTES, DEFAULT_COOLDOWN_MINUTES,
@@ -51,7 +51,6 @@ async def list_markets(
     status: Optional[str] = None,
     limit: Optional[int] = None,
     offset: Optional[int] = None,
-    bg: BackgroundTasks = BackgroundTasks(),
 ):
     """List markets, filtered by status, with pagination."""
     db = get_db()
@@ -75,17 +74,9 @@ async def list_markets(
         return cached["data"]
 
     markets = db.list_markets_with_creators()
-    bg.add_task(bg_transition_expired_markets)
 
-    now = datetime.now(timezone.utc)
-    transitioned = False
-    for m in markets:
-        if m["status"] == MarketStatus.OPEN and m["closes_at"] <= now:
-            m["status"] = MarketStatus.RESOLVING
-            transitioned = True
-
-    if transitioned:
-        market_cache.invalidate()
+    # Markets no longer auto-transition based on closes_at (issue #115).
+    # They remain OPEN until explicitly resolved.
 
     if status_filter == "ALL":
         pass
@@ -167,8 +158,6 @@ async def get_market(market_id: str):
     market = db.get_market(market_id)
     if not market:
         return error_response(404, "Market not found", ErrorCode.MARKET_NOT_FOUND)
-
-    maybe_transition_market(market, market_id)
 
     creator = db.get_user(market["creator_id"]) if market["creator_id"] else None
     creator_username = creator["username"] if creator else None
@@ -283,11 +272,12 @@ async def create_market(req: MarketCreate, user: dict = Depends(require_auth)):
 async def resolve_market(market_id: str, req: MarketResolve, user: dict = Depends(require_auth)):
     """Resolve a market. Only creator can resolve.
 
-    Committee window enforcement (issue #107):
-    - If a committee exists with >1 member and the deadline hasn't passed,
-      the creator must use the committee vote endpoint instead.
-    - After the 30-minute deadline, creator regains unilateral resolve.
-    - Solo creator (no other traders) can resolve immediately.
+    Issue #115: Markets remain OPEN and tradeable until resolution.
+    - Creator calls resolve on an OPEN market → initiates resolution.
+    - If solo creator (no other traders): resolves immediately.
+    - If other traders exist: forms committee, transitions to RESOLVING,
+      and requires committee vote process (30-minute window).
+    - After the committee deadline, creator regains unilateral resolve.
     """
     db = get_db()
     validate_uuid(market_id, "market_id")
@@ -301,9 +291,27 @@ async def resolve_market(market_id: str, req: MarketResolve, user: dict = Depend
     if market["status"] == MarketStatus.RESOLVED:
         return error_response(400, "Market already resolved", ErrorCode.ALREADY_RESOLVED)
 
-    maybe_transition_market(market, market_id)
+    # If market is OPEN, initiate the resolution process (issue #115)
+    if market["status"] == MarketStatus.OPEN:
+        committee = form_committee(market_id, market)
+        db.update_market_status(market_id, MarketStatus.RESOLVING)
+        market["status"] = MarketStatus.RESOLVING
 
-    # Committee window enforcement
+        # If committee has multiple members, require the committee vote process
+        if len(committee) > 1:
+            resolution_deadline = market.get("resolution_deadline")
+            now = datetime.now(timezone.utc)
+            if resolution_deadline and now < resolution_deadline:
+                remaining = (resolution_deadline - now).total_seconds() / 60
+                return error_response(403,
+                    f"Committee resolution window is active. Use POST /markets/{market_id}/resolution-vote instead. "
+                    f"Creator can resolve unilaterally in {remaining:.0f} minutes.",
+                    ErrorCode.COMMITTEE_WINDOW_ACTIVE,
+                    detail={"resolution_deadline": resolution_deadline.isoformat(),
+                            "remaining_minutes": round(remaining, 1)})
+        # Solo creator → falls through to resolve immediately
+
+    # Market is RESOLVING — check committee window enforcement (issue #107)
     committee = market.get("committee") or []
     resolution_deadline = market.get("resolution_deadline")
     if len(committee) > 1 and resolution_deadline:
@@ -358,13 +366,13 @@ async def cast_committee_vote(market_id: str, req: CommitteeVoteRequest, user: d
     if not market:
         return error_response(404, "Market not found", ErrorCode.MARKET_NOT_FOUND)
 
-    maybe_transition_market(market, market_id)
-
     if market["status"] == MarketStatus.RESOLVED:
         return error_response(400, "Market already resolved", ErrorCode.ALREADY_RESOLVED)
 
     if market["status"] != MarketStatus.RESOLVING:
-        return error_response(400, "Market is not in RESOLVING state", ErrorCode.MARKET_CLOSED)
+        return error_response(400,
+            "Market is not in RESOLVING state. The creator must first call POST /markets/{id}/resolve to initiate resolution.",
+            ErrorCode.MARKET_CLOSED)
 
     # Form committee if not yet formed (e.g., market was set to RESOLVING externally)
     committee = market.get("committee")
@@ -431,8 +439,6 @@ async def get_committee_status(market_id: str):
     market = db.get_market(market_id)
     if not market:
         return error_response(404, "Market not found", ErrorCode.MARKET_NOT_FOUND)
-
-    maybe_transition_market(market, market_id)
 
     committee = market.get("committee") or []
     resolution_deadline = market.get("resolution_deadline")
@@ -628,8 +634,6 @@ async def request_resolution(market_id: str, user: dict = Depends(require_auth))
 
     if market["status"] == MarketStatus.RESOLVED:
         return error_response(400, "Market already resolved", ErrorCode.ALREADY_RESOLVED)
-
-    maybe_transition_market(market, market_id)
 
     anthropic_key = os.getenv("ANTHROPIC_API_KEY")
     brave_key = os.getenv("BRAVE_API_KEY")

--- a/routes/trading.py
+++ b/routes/trading.py
@@ -4,7 +4,6 @@ Trading endpoints — bet, sell, positions, bet history.
 
 import logging
 import uuid
-from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Response
@@ -12,7 +11,7 @@ from fastapi import APIRouter, Depends, Response
 from auth import require_auth
 from cpmm import CpmmState, calculate_cpmm_purchase, calculate_cpmm_sale, get_cpmm_probability
 from deps import (
-    get_db, validate_uuid, clamp_pagination, maybe_transition_market,
+    get_db, validate_uuid, clamp_pagination,
     TRADE_FEE_RATE, CREATOR_FEE_SHARE,
 )
 from errors import error_response, ErrorCode
@@ -71,15 +70,16 @@ async def place_bet(market_id: str, req: BetRequest, response: Response, user: d
     if not market:
         return error_response(404, "Market not found", ErrorCode.MARKET_NOT_FOUND)
 
-    maybe_transition_market(market, market_id)
-
+    # Markets remain tradeable until resolution (issue #115).
+    # closes_at is display-only; only RESOLVING/RESOLVED blocks trading.
     if market["status"] != MarketStatus.OPEN:
-        status_msg = "Market is resolving (closed, awaiting resolution)" if market["status"] == MarketStatus.RESOLVING else "Market is not open for trading"
+        if market["status"] == MarketStatus.RESOLVING:
+            status_msg = "Market is being resolved — trading is suspended"
+        elif market["status"] == MarketStatus.RESOLVED:
+            status_msg = "Market has been resolved"
+        else:
+            status_msg = "Market is not open for trading"
         return error_response(400, status_msg, ErrorCode.MARKET_CLOSED)
-
-    now = datetime.now(timezone.utc)
-    if market["closes_at"] <= now:
-        return error_response(400, "Market has closed", ErrorCode.MARKET_CLOSED)
 
     trade_fee = req.amount * TRADE_FEE_RATE
     total_cost = req.amount + trade_fee
@@ -197,15 +197,15 @@ async def sell_shares(market_id: str, req: SellRequest, user: dict = Depends(req
     if not market:
         return error_response(404, "Market not found", ErrorCode.MARKET_NOT_FOUND)
 
-    maybe_transition_market(market, market_id)
-
+    # Markets remain tradeable until resolution (issue #115).
     if market["status"] != MarketStatus.OPEN:
-        status_msg = "Market is resolving (closed, awaiting resolution)" if market["status"] == MarketStatus.RESOLVING else "Market is not open for trading"
+        if market["status"] == MarketStatus.RESOLVING:
+            status_msg = "Market is being resolved — trading is suspended"
+        elif market["status"] == MarketStatus.RESOLVED:
+            status_msg = "Market has been resolved"
+        else:
+            status_msg = "Market is not open for trading"
         return error_response(400, status_msg, ErrorCode.MARKET_CLOSED)
-
-    now = datetime.now(timezone.utc)
-    if market["closes_at"] <= now:
-        return error_response(400, "Market has closed", ErrorCode.MARKET_CLOSED)
 
     position = db.get_position(market_id, user["id"])
     if not position:

--- a/test_api_flows.py
+++ b/test_api_flows.py
@@ -327,7 +327,12 @@ class TestSellPosition:
 # ===================================================================
 
 class TestResolveMarket:
-    """POST /markets/{id}/resolve — payouts to winners."""
+    """POST /markets/{id}/resolve — payouts to winners.
+
+    Issue #115: resolving an OPEN market with multiple traders now forms
+    a committee and returns 403 to start the committee vote window.
+    These tests expire the deadline so the creator can resolve immediately.
+    """
 
     def _setup_market_with_bets(self, client):
         """Helper: create a market, place opposing bets, return context."""
@@ -353,13 +358,31 @@ class TestResolveMarket:
             "market_id": market_id,
         }
 
+    def _initiate_and_force_resolve(self, client, market_id, creator_headers, outcome):
+        """Initiate resolution (forms committee), expire deadline, then resolve.
+
+        Issue #115: resolving an OPEN market with traders first forms a
+        committee (returns 403). We expire the deadline so the second
+        resolve call goes through immediately.
+        """
+        resp = client.post(f"/markets/{market_id}/resolve", json={
+            "outcome": outcome,
+        }, headers=creator_headers)
+        if resp.status_code == 403:
+            # Committee window active — expire it
+            m = db._markets[market_id]
+            m["resolution_deadline"] = datetime.now(timezone.utc) - timedelta(minutes=1)
+            resp = client.post(f"/markets/{market_id}/resolve", json={
+                "outcome": outcome,
+            }, headers=creator_headers)
+        return resp
+
     def test_resolve_yes_pays_yes_holders(self, client):
         ctx = self._setup_market_with_bets(client)
         yes_bal_before = client.get("/me", headers=ctx["yes_bettor"]["headers"]).json()["balance"]
 
-        resp = client.post(f"/markets/{ctx['market_id']}/resolve", json={
-            "outcome": "YES",
-        }, headers=ctx["creator"]["headers"])
+        resp = self._initiate_and_force_resolve(
+            client, ctx["market_id"], ctx["creator"]["headers"], "YES")
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] == "RESOLVED"
@@ -372,9 +395,8 @@ class TestResolveMarket:
         ctx = self._setup_market_with_bets(client)
         no_bal_before = client.get("/me", headers=ctx["no_bettor"]["headers"]).json()["balance"]
 
-        resp = client.post(f"/markets/{ctx['market_id']}/resolve", json={
-            "outcome": "NO",
-        }, headers=ctx["creator"]["headers"])
+        resp = self._initiate_and_force_resolve(
+            client, ctx["market_id"], ctx["creator"]["headers"], "NO")
         assert resp.status_code == 200
 
         no_bal_after = client.get("/me", headers=ctx["no_bettor"]["headers"]).json()["balance"]
@@ -384,18 +406,16 @@ class TestResolveMarket:
         ctx = self._setup_market_with_bets(client)
         no_bal_before = client.get("/me", headers=ctx["no_bettor"]["headers"]).json()["balance"]
 
-        client.post(f"/markets/{ctx['market_id']}/resolve", json={
-            "outcome": "YES",
-        }, headers=ctx["creator"]["headers"])
+        self._initiate_and_force_resolve(
+            client, ctx["market_id"], ctx["creator"]["headers"], "YES")
 
         no_bal_after = client.get("/me", headers=ctx["no_bettor"]["headers"]).json()["balance"]
         assert no_bal_after == pytest.approx(no_bal_before, abs=0.01), "Loser balance should not change"
 
     def test_resolve_twice_fails(self, client):
         ctx = self._setup_market_with_bets(client)
-        client.post(f"/markets/{ctx['market_id']}/resolve", json={
-            "outcome": "YES",
-        }, headers=ctx["creator"]["headers"])
+        self._initiate_and_force_resolve(
+            client, ctx["market_id"], ctx["creator"]["headers"], "YES")
 
         resp = client.post(f"/markets/{ctx['market_id']}/resolve", json={
             "outcome": "NO",
@@ -433,16 +453,64 @@ class TestEdgeCases:
         }, headers=bettor["headers"])
         assert resp.status_code == 400
 
-    def test_bet_on_expired_market(self, client):
-        """Market whose closes_at is in the past should auto-transition."""
+    def test_bet_after_event_end_time(self, client):
+        """Market past closes_at is still tradeable (issue #115).
+
+        closes_at is display-only ('event end time'). Trading continues
+        until the creator explicitly resolves the market.
+        """
         creator = _register_agent(client, "edge_creator2")
-        # Create with very short window then fast-forward close time
         market = _create_market(client, creator["headers"], minutes=30)
         market_id = market["id"]
-        # Manually set closes_at to the past in storage
+        # Move closes_at into the past — trading should still work
         db._markets[market_id]["closes_at"] = datetime.now(timezone.utc) - timedelta(hours=1)
 
         bettor = _register_agent(client, "edge_bettor2")
+        resp = client.post(f"/markets/{market_id}/bet", json={
+            "outcome": "YES", "amount": 10,
+        }, headers=bettor["headers"])
+        assert resp.status_code == 200, "Trading should work after event end time"
+
+    def test_sell_after_event_end_time(self, client):
+        """Selling works after closes_at (issue #115)."""
+        creator = _register_agent(client, "sell_after_close_creator")
+        market = _create_market(client, creator["headers"])
+        market_id = market["id"]
+
+        trader = _register_agent(client, "sell_after_close_trader")
+        buy = client.post(f"/markets/{market_id}/bet", json={
+            "outcome": "YES", "amount": 50,
+        }, headers=trader["headers"]).json()
+
+        # Move closes_at into the past
+        db._markets[market_id]["closes_at"] = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        resp = client.post(f"/markets/{market_id}/sell", json={
+            "outcome": "YES", "shares": buy["shares"],
+        }, headers=trader["headers"])
+        assert resp.status_code == 200, "Sell should work after event end time"
+
+    def test_only_resolution_stops_trading(self, client):
+        """Only resolution stops trading, not closes_at (issue #115)."""
+        creator = _register_agent(client, "only_res_creator")
+        market = _create_market(client, creator["headers"])
+        market_id = market["id"]
+
+        bettor = _register_agent(client, "only_res_bettor")
+
+        # Move closes_at into the past — trading should still work
+        db._markets[market_id]["closes_at"] = datetime.now(timezone.utc) - timedelta(hours=1)
+        resp = client.post(f"/markets/{market_id}/bet", json={
+            "outcome": "YES", "amount": 10,
+        }, headers=bettor["headers"])
+        assert resp.status_code == 200
+
+        # Now resolve the market
+        client.post(f"/markets/{market_id}/resolve", json={
+            "outcome": "YES",
+        }, headers=creator["headers"])
+
+        # Trading should now fail
         resp = client.post(f"/markets/{market_id}/bet", json={
             "outcome": "YES", "amount": 10,
         }, headers=bettor["headers"])

--- a/test_committee.py
+++ b/test_committee.py
@@ -101,12 +101,12 @@ def _place_bet(client: TestClient, market_id: str, headers: dict,
 
 
 def _force_resolving(market_id: str):
-    """Force a market into RESOLVING state (bypass time check)."""
-    market = db.get_market(market_id)
-    market["status"] = MarketStatus.RESOLVING
-    market["closes_at"] = datetime.now(timezone.utc) - timedelta(minutes=1)
-    if hasattr(db, '_use_memory') and db._use_memory:
-        db._markets[market_id] = market
+    """Force a market into RESOLVING state for testing.
+
+    Issue #115: markets no longer auto-transition based on closes_at.
+    This helper directly sets RESOLVING status for tests that need it.
+    """
+    db.update_market_status(market_id, MarketStatus.RESOLVING)
 
 
 # ---------------------------------------------------------------------------
@@ -238,10 +238,14 @@ class TestCommitteeFormation:
         assert trader1["user_id"] in committee
         assert len(committee) == 2
 
-    def test_committee_formed_on_transition(self):
-        """Committee is auto-formed when market transitions via maybe_transition_market."""
-        from deps import maybe_transition_market
+    def test_committee_formed_on_resolve_attempt(self):
+        """Committee is formed when creator attempts to resolve an OPEN market with traders (issue #115).
 
+        Since markets no longer auto-transition at closes_at, the committee
+        is formed when the creator first calls POST /resolve on an OPEN market.
+        If other traders exist, the endpoint forms a committee, transitions to
+        RESOLVING, and returns 403 to start the committee vote window.
+        """
         creator = _register_agent(client, "creator_auto")
         trader = _register_agent(client, "trader_auto")
         market = _create_market(client, creator["headers"])
@@ -249,12 +253,13 @@ class TestCommitteeFormation:
 
         _place_bet(client, market_id, trader["headers"], "YES", 50)
 
-        # Force the market past closes_at
+        # Creator tries to resolve OPEN market with traders → committee formed, 403
+        resp = client.post(f"/markets/{market_id}/resolve",
+            json={"outcome": "YES"}, headers=creator["headers"])
+        assert resp.status_code == 403
+        assert "COMMITTEE_WINDOW_ACTIVE" in resp.text
+
         m = db.get_market(market_id)
-        m["closes_at"] = datetime.now(timezone.utc) - timedelta(minutes=1)
-
-        maybe_transition_market(m, market_id)
-
         assert m["status"] == MarketStatus.RESOLVING
         assert m.get("committee") is not None
         assert creator["user_id"] in m["committee"]


### PR DESCRIPTION
## Summary
Implements #115: Markets remain tradeable until the creator explicitly resolves them. `closes_at` becomes display-only ('event end time').

## What Changed

### Core behavior
- **Trading continues past `closes_at`** — bets and sells work regardless of event end time
- **Only resolution stops trading** — `POST /markets/{id}/resolve` is the sole trading cutoff
- **Auto-transition removed** — `maybe_transition_market()` and `bg_transition_expired_markets()` are now no-ops

### Resolve endpoint (new flow)
When creator calls `POST /resolve` on an **OPEN** market:
- **Solo creator** (no other traders): resolves immediately  
- **Multiple traders**: forms committee → transitions to RESOLVING → returns 403 with committee window info
- After committee deadline expires: creator can resolve unilaterally

### Status flow
```
OPEN → RESOLVING → RESOLVED
```
- `CLOSED` status deprecated (kept in enum for backward compat)
- `OPEN`: tradeable
- `RESOLVING`: resolution in progress, trading suspended
- `RESOLVED`: final, payouts distributed

## Files Changed (6 files, +169/-103)
| File | Change |
|------|--------|
| `deps.py` | `maybe_transition_market()` + `bg_transition_expired_markets()` → no-ops |
| `routes/trading.py` | Remove `closes_at` checks and auto-transition calls from bet/sell |
| `routes/markets.py` | Remove inline transitions, update resolve to handle OPEN markets |
| `models.py` | Annotate MarketStatus enum (CLOSED = deprecated) |
| `test_api_flows.py` | 3 new tests + updated resolve/edge case tests |
| `test_committee.py` | Updated `_force_resolving`, new resolve-attempt test |

## Test Results
```
206 passed in 4.81s
```
All existing tests pass. New tests added:
- `test_bet_after_event_end_time` — trading works past closes_at ✅
- `test_sell_after_event_end_time` — selling works past closes_at ✅
- `test_only_resolution_stops_trading` — trades work until resolve, then fail ✅
- `test_committee_formed_on_resolve_attempt` — committee forms on first resolve call ✅

## Builds on
- PR #116 (pool residual fix) ✅ already merged
- PR #117 (committee resolution) ✅ already merged

Closes #115