### PR TITLE
feat: Add structured JSON logging (closes #64)

### DIFF
--- a/api.py
+++ b/api.py
@@ -14,7 +14,6 @@ Route handlers live in the ``routes/`` package.  This file wires up:
   - Lifespan (startup / shutdown)
 """
 
-import logging
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone, timedelta
@@ -29,6 +28,7 @@ from errors import (
     http_exception_handler, unhandled_exception_handler,
 )
 from fastapi import HTTPException
+from logger import configure_logging, get_logger
 from middleware import configure_middleware
 from models import Outcome
 from routes import (
@@ -42,7 +42,10 @@ from routes import (
 from sse import router as sse_router
 from storage import Storage
 
-logger = logging.getLogger(__name__)
+# Configure structured JSON logging before anything else
+configure_logging()
+
+logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Global storage instance — shared via deps module
@@ -61,10 +64,10 @@ async def lifespan(app: FastAPI):
         db.create_user("demo-user", "demo_user", balance=0.0)
     market_count = db.count_markets()
     user_count = db.count_users()
-    print(f"MoltMarkets API started with {market_count} markets, {user_count} users")
+    logger.info("api_started", market_count=market_count, user_count=user_count)
     yield
     db.close_pool()
-    print("MoltMarkets API shutting down")
+    logger.info("api_shutdown")
 
 
 # ---------------------------------------------------------------------------

--- a/middleware.py
+++ b/middleware.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from errors import APIError, ErrorCode
 from idempotency import IdempotencyMiddleware
+from logger import RequestIDMiddleware, RequestLoggingMiddleware
 
 
 # ---------------------------------------------------------------------------
@@ -109,3 +110,12 @@ def configure_middleware(app: FastAPI) -> None:
     # Idempotency middleware — must be added AFTER CORSMiddleware so CORS
     # headers are applied even to cached/replayed responses.
     app.add_middleware(IdempotencyMiddleware)
+
+    # Request logging middleware — logs request/response with timing.
+    # Added after IdempotencyMiddleware so it captures all requests including
+    # idempotent replays.
+    app.add_middleware(RequestLoggingMiddleware)
+
+    # Request ID middleware — outermost, ensures every request gets a
+    # correlation ID available to all inner middleware and route handlers.
+    app.add_middleware(RequestIDMiddleware)

--- a/resolver.py
+++ b/resolver.py
@@ -7,10 +7,13 @@ Majority (5+) decides the outcome.
 
 import asyncio
 import httpx
+import logging
 from datetime import datetime, timezone
 from typing import List, Dict, Optional, Tuple
 from dataclasses import dataclass
 import json
+
+logger = logging.getLogger(__name__)
 
 # Configuration
 NUM_RESOLVERS = 9
@@ -49,7 +52,7 @@ async def web_search(query: str, api_key: str, num_results: int = 5) -> List[Dic
                 })
             return results
     except Exception as e:
-        print(f"Search error: {e}")
+        logger.error("Search error: %s", e)
         return []
 
 
@@ -120,7 +123,7 @@ Respond in this exact JSON format:
             )
             
             if response.status_code != 200:
-                print(f"Agent {agent_id} API error: {response.status_code}")
+                logger.error("Agent %s API error: %d", agent_id, response.status_code)
                 return None
             
             data = response.json()
@@ -145,11 +148,11 @@ Respond in this exact JSON format:
                             created_at=datetime.now(timezone.utc)
                         )
             except json.JSONDecodeError:
-                print(f"Agent {agent_id} JSON parse error")
+                logger.error("Agent %s JSON parse error", agent_id)
                 return None
                 
     except Exception as e:
-        print(f"Agent {agent_id} error: {e}")
+        logger.error("Agent %s error: %s", agent_id, e)
         return None
     
     return None

--- a/storage/base.py
+++ b/storage/base.py
@@ -5,6 +5,7 @@ Contains Storage.__init__, connection pool, _init_db, _save, and constants.
 """
 
 import json
+import logging
 import os
 import warnings
 from datetime import datetime, timezone
@@ -16,6 +17,8 @@ from psycopg2 import pool
 from psycopg2.extras import RealDictCursor
 
 from models import MarketStatus, Outcome
+
+logger = logging.getLogger(__name__)
 
 
 class BaseStorage:
@@ -33,7 +36,7 @@ class BaseStorage:
             self._init_pool()
             self._init_db()
         else:
-            print("Warning: DATABASE_URL not set, using in-memory storage (data will be lost on restart)")
+            logger.warning("DATABASE_URL not set, using in-memory storage (data will be lost on restart)")
             # Fallback to in-memory for local dev without DB
             self._use_memory = True
             self._markets: Dict[str, dict] = {}
@@ -50,9 +53,9 @@ class BaseStorage:
         if self._pool is not None:
             try:
                 self._pool.closeall()
-                print("Connection pool closed")
+                logger.info("Connection pool closed")
             except Exception as e:
-                print(f"Warning: error closing connection pool: {e}")
+                logger.warning("Error closing connection pool: %s", e)
 
     def _init_pool(self):
         """Initialize a thread-safe connection pool.
@@ -90,7 +93,7 @@ class BaseStorage:
             keepalives_count=3,          # Give up after 3 missed keepalives
             options='-c statement_timeout=30000',  # 30s query timeout
         )
-        print(f"ThreadedConnectionPool initialized (min={min_conn}, max={max_conn}, keepalives=on, statement_timeout=30s)")
+        logger.info("ThreadedConnectionPool initialized (min=%d, max=%d, keepalives=on, statement_timeout=30s)", min_conn, max_conn)
 
     def _get_conn(self):
         """Get a database connection from the pool.
@@ -352,7 +355,7 @@ class BaseStorage:
                 cur.execute("CREATE INDEX IF NOT EXISTS idx_markets_created_at ON markets(created_at DESC)")
 
                 conn.commit()
-                print("Database tables initialized")
+                logger.info("Database tables initialized")
         finally:
             self._put_conn(conn)
 


### PR DESCRIPTION
## Summary

Wires up the existing `logger.py` module (structlog-based structured JSON logging) and replaces all production `print()` statements with proper logger calls.

Closes #64

## Changes

### `api.py`
- Import and call `configure_logging()` at module load to activate structlog
- Replace `print()` in lifespan with structured `logger.info()` calls (`api_started`, `api_shutdown`)

### `middleware.py`
- Wire `RequestIDMiddleware` — assigns/propagates `X-Request-ID` correlation IDs on every request
- Wire `RequestLoggingMiddleware` — logs request start/completion with method, path, status, and duration

### `storage/base.py`
- Replace 4 `print()` calls (pool init, warnings, table init) with `logger.info()` / `logger.warning()`

### `resolver.py`
- Replace 4 `print()` calls (search errors, agent vote errors) with `logger.error()`

### What's NOT changed
- `print()` in `if __name__ == "__main__"` test runners (cpmm.py, api.py) — these are dev-only interactive output, not production code paths
- No third-party deps added — `structlog` was already in requirements.txt
- No other refactors — logging only

## Log Output

**Production** (default): JSON lines to stdout
```json
{"event": "api_started", "market_count": 42, "user_count": 15, "service": "moltmarkets-api", "timestamp": "2025-07-19T12:00:00Z", "level": "info"}
{"event": "request_started", "method": "GET", "path": "/markets", "request_id": "abc-123", "level": "info"}
{"event": "request_completed", "method": "GET", "path": "/markets", "status_code": 200, "duration_ms": 12.5, "request_id": "abc-123", "level": "info"}
```

**Development** (`DEBUG=1`): colored console output with the same structured fields

## Testing
- All files pass `py_compile` syntax check
- Middleware ordering preserves existing CORS → Idempotency stack; logging middlewares added as outermost layer