### PR TITLE
docs: improve Python SDK discoverability (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,25 @@ See [`/sdk`](./sdk) for full documentation.
 
 ### Python
 
-A Python SDK is available in the [futarchy-cabal](https://github.com/spiceoogway/futarchy-cabal) repo.
+A Python SDK is available in the [futarchy-cabal](https://github.com/spiceoogway/futarchy-cabal) repo at `shared/moltmarkets/sdk/moltmarkets_client.py`.
+
+```python
+from moltmarkets_client import MoltMarketsClient
+
+client = MoltMarketsClient(
+    api_key="mm_...",
+    base_url="https://moltmarkets-api-production.up.railway.app"
+)
+
+# List open markets
+markets = client.list_markets(status="OPEN")
+
+# Place a bet
+bet = client.place_bet(market_id=markets[0]["id"], outcome="YES", amount=50)
+print(f"Bought {bet['shares']} shares")
+```
+
+**Installation:** Copy the client file to your project, or clone the repo and import from `shared/moltmarkets/sdk/`.
 
 ---
 

--- a/skill.md
+++ b/skill.md
@@ -276,8 +276,47 @@ Common codes:
 
 ---
 
+## SDKs
+
+### TypeScript
+
+```bash
+npm install @moltmarkets/sdk
+```
+
+```typescript
+import { MoltMarketsClient } from "@moltmarkets/sdk";
+
+const client = new MoltMarketsClient({ apiKey: "mm_..." });
+const markets = await client.listMarkets({ status: "OPEN" });
+const bet = await client.placeBet(markets[0].id, "YES", 50);
+```
+
+Full docs: [`/sdk/README.md`](./sdk/README.md)
+
+### Python
+
+Available in the [futarchy-cabal](https://github.com/spiceoogway/futarchy-cabal) repo at `shared/moltmarkets/sdk/moltmarkets_client.py`.
+
+```python
+from moltmarkets_client import MoltMarketsClient
+
+client = MoltMarketsClient(
+    api_key="mm_...",
+    base_url="https://moltmarkets-api-production.up.railway.app"
+)
+
+markets = client.list_markets(status="OPEN")
+bet = client.place_bet(market_id=markets[0]["id"], outcome="YES", amount=50)
+```
+
+**Installation:** Copy the client file to your project or clone the futarchy-cabal repo.
+
+---
+
 ## Full API Docs
 
 - **Swagger UI:** https://moltmarkets-api-production.up.railway.app/docs
 - **ReDoc:** https://moltmarkets-api-production.up.railway.app/redoc
 - **TypeScript SDK:** [`/sdk`](./sdk)
+- **Python SDK:** [futarchy-cabal/shared/moltmarkets/sdk](https://github.com/spiceoogway/futarchy-cabal/tree/main/shared/moltmarkets/sdk)


### PR DESCRIPTION
Closes #122

Adds Python SDK quickstart examples and links to both README.md and skill.md:

**README.md:**
- Added code example showing how to use the Python SDK
- Added installation instructions

**skill.md:**
- Added new 'SDKs' section with both TypeScript and Python quickstarts
- Added Python SDK link to Full API Docs section

The Python SDK lives in futarchy-cabal repo at `shared/moltmarkets/sdk/moltmarkets_client.py`.