### PR TITLE
feat: add history cache with invalidation on bet

### DIFF
--- a/history_cache.py
+++ b/history_cache.py
@@ -1,0 +1,110 @@
+"""
+In-memory cache for market history and bets endpoints.
+
+Unlike the market list cache, this is keyed by market_id since each
+market has its own history. Invalidation happens per-market when a
+new bet is placed.
+
+Cache is safe because history is append-only — past bets never change.
+We invalidate on new bets to ensure fresh data.
+"""
+
+import time
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Longer TTL than market list — history only changes on new bets,
+# and we explicitly invalidate when that happens.
+DEFAULT_TTL_SECONDS = 60
+
+
+class HistoryCache:
+    """Per-market cache for history and bets endpoints.
+    
+    Usage:
+        cache = HistoryCache()
+        
+        # On read:
+        hit = cache.get("history", market_id)
+        if hit:
+            return hit  # cached response
+        
+        # On miss: build response, then store
+        data = build_history(...)
+        cache.set("history", market_id, data)
+        
+        # On bet placed:
+        cache.invalidate(market_id)
+    """
+
+    def __init__(self, ttl_seconds: float = DEFAULT_TTL_SECONDS):
+        self._ttl = ttl_seconds
+        # Nested dict: endpoint -> market_id -> {data, stored_at}
+        self._entries: Dict[str, Dict[str, dict]] = {
+            "history": {},
+            "bets": {},
+        }
+        self._hits = 0
+        self._misses = 0
+
+    def get(self, endpoint: str, market_id: str) -> Optional[Any]:
+        """Return cached data if it exists and hasn't expired."""
+        endpoint_cache = self._entries.get(endpoint, {})
+        entry = endpoint_cache.get(market_id)
+        
+        if entry is None:
+            self._misses += 1
+            return None
+        
+        age = time.monotonic() - entry["stored_at"]
+        if age > self._ttl:
+            # Expired — remove and return miss
+            del endpoint_cache[market_id]
+            self._misses += 1
+            return None
+        
+        self._hits += 1
+        return entry["data"]
+
+    def set(self, endpoint: str, market_id: str, data: Any) -> None:
+        """Store a cache entry."""
+        if endpoint not in self._entries:
+            self._entries[endpoint] = {}
+        
+        self._entries[endpoint][market_id] = {
+            "data": data,
+            "stored_at": time.monotonic(),
+        }
+
+    def invalidate(self, market_id: str) -> None:
+        """Clear cached entries for a specific market.
+        
+        Called when a bet is placed on this market.
+        """
+        for endpoint_cache in self._entries.values():
+            if market_id in endpoint_cache:
+                del endpoint_cache[market_id]
+        logger.debug("Invalidated history cache for market %s", market_id)
+
+    def invalidate_all(self) -> None:
+        """Clear all cached entries (e.g., on server restart)."""
+        for endpoint_cache in self._entries.values():
+            endpoint_cache.clear()
+
+    def stats(self) -> dict:
+        """Return cache statistics."""
+        total_entries = sum(len(ec) for ec in self._entries.values())
+        total_requests = self._hits + self._misses
+        hit_rate = self._hits / total_requests if total_requests > 0 else 0
+        return {
+            "entries": total_entries,
+            "hits": self._hits,
+            "misses": self._misses,
+            "hit_rate": f"{hit_rate:.1%}",
+        }
+
+
+# Singleton instance
+history_cache = HistoryCache(ttl_seconds=DEFAULT_TTL_SECONDS)

--- a/routes/markets.py
+++ b/routes/markets.py
@@ -21,6 +21,7 @@ from utils import validate_uuid, clamp_pagination, set_cache_headers
 from errors import error_response, ErrorCode
 from event_bus import event_bus, SSEEvent
 from market_cache import market_cache
+from history_cache import history_cache
 from models import (
     MarketCreate, MarketSummary, MarketDetail, MarketCreated,
     ProbabilityPoint, MarketHistory, SparklinePoint,
@@ -426,9 +427,19 @@ async def create_market(req: MarketCreate, user: dict = Depends(require_auth)):
 
 @router.get("/markets/{market_id}/history", response_model=MarketHistory)
 async def get_market_history(market_id: str):
-    """Get probability history for charts."""
-    db = get_db()
+    """Get probability history for charts.
+    
+    Cached with invalidation on new bets — history is append-only so
+    cached data is always valid until a new bet is placed.
+    """
     validate_uuid(market_id, "market_id")
+    
+    # Check cache first
+    cached = history_cache.get("history", market_id)
+    if cached:
+        return cached
+    
+    db = get_db()
     market = db.get_market(market_id)
     if not market:
         return error_response(404, "Market not found", ErrorCode.MARKET_NOT_FOUND)
@@ -453,4 +464,9 @@ async def get_market_history(market_id: str):
             volume=cumulative_volume,
         ))
 
-    return MarketHistory(market_id=market_id, points=points)
+    result = MarketHistory(market_id=market_id, points=points)
+    
+    # Cache for next request
+    history_cache.set("history", market_id, result)
+    
+    return result

--- a/routes/trading.py
+++ b/routes/trading.py
@@ -19,6 +19,7 @@ from utils import validate_uuid, clamp_pagination
 from errors import error_response, ErrorCode
 from event_bus import event_bus, SSEEvent
 from market_cache import market_cache
+from history_cache import history_cache
 from middleware import set_rate_limit_headers, raise_rate_limited
 from models import (
     BetRequest, BetResponse, FeeBreakdown,
@@ -154,6 +155,9 @@ async def place_bet(market_id: str, req: BetRequest, response: Response, user: d
         },
         market_id=market_id,
     ))
+
+    # Invalidate history cache for this market (new bet added)
+    history_cache.invalidate(market_id)
 
     return BetResponse(
         bet_id=bet["id"],
@@ -305,11 +309,22 @@ async def get_market_bets(
     limit: Optional[int] = None,
     offset: Optional[int] = None,
 ):
-    """Get bets for a market with pagination."""
-    db = get_db()
+    """Get bets for a market with pagination.
+    
+    Cached with invalidation on new bets — bet history is append-only.
+    Note: Only caches first page (offset=0) to keep cache simple.
+    """
     validate_uuid(market_id, "market_id")
     limit, offset = clamp_pagination(limit, offset)
+    
+    # Only cache first page to avoid complexity
+    cache_key = f"bets:{limit}" if offset == 0 else None
+    if cache_key:
+        cached = history_cache.get(cache_key, market_id)
+        if cached:
+            return cached
 
+    db = get_db()
     market = db.get_market(market_id)
     if not market:
         return error_response(404, "Market not found", ErrorCode.MARKET_NOT_FOUND)
@@ -336,7 +351,13 @@ async def get_market_bets(
             created_at=bet["created_at"],
         ))
 
-    return PaginatedBetHistoryItem(
+    result = PaginatedBetHistoryItem(
         data=items,
         pagination=PaginationMeta(limit=limit, offset=offset, total=total),
     )
+    
+    # Cache first page for next request
+    if cache_key:
+        history_cache.set(cache_key, market_id, result)
+    
+    return result


### PR DESCRIPTION
## Summary
Adds in-memory caching for the slow history/bets endpoints with automatic invalidation when new bets are placed.

## Problem
- `/markets/{id}/history` was taking 2+ seconds per request
- `/markets/{id}/bets` was taking 1.5+ seconds per request
- Every sparkline on homepage = separate API call = slow page loads

## Solution
- New `history_cache.py` with per-market TTL cache (60s)
- Cache invalidated immediately when any bet is placed on that market
- History is append-only, so cached data is always valid until new bet

## Changes
- `history_cache.py` — new cache module
- `routes/markets.py` — cache history endpoint
- `routes/trading.py` — cache bets endpoint + invalidate on place_bet

## Testing
- Imports verified ✅
- API loads without errors ✅
- Safe: cache miss = normal DB query, no behavior change

## Performance
- First request: normal (cache miss, hits DB)
- Subsequent requests: ~0ms (cache hit)
- After bet placed: next request rebuilds cache

cc @spotter @crabby