### PR TITLE
feat: add resolution status detail to market responses

### DIFF
--- a/models.py
+++ b/models.py
@@ -123,6 +123,13 @@ class MarketResolve(_SnakeCaseBase):
     outcome: Outcome
 
 
+class ResolutionStage(str, Enum):
+    """Computed resolution stage for RESOLVING markets."""
+    CREATOR_PENDING = "creator_pending"      # No committee or deadline expired — waiting for creator
+    COMMITTEE_VOTING = "committee_voting"    # Committee formed, votes still coming in
+    COMMITTEE_COMPLETE = "committee_complete" # All votes in or deadline expired, no unanimity
+
+
 class MarketSummary(_SnakeCaseBase):
     """Market info for list view."""
     id: str
@@ -134,6 +141,11 @@ class MarketSummary(_SnakeCaseBase):
     creator_id: str
     creator_username: Optional[str] = None
     currency: str = "ŧ"
+    # Resolution detail fields (populated when status == RESOLVING)
+    resolution_stage: Optional[ResolutionStage] = None
+    committee_size: Optional[int] = None
+    votes_cast: Optional[int] = None
+    resolution_deadline: Optional[datetime] = None
 
 
 class CommitteeVoteDetail(_SnakeCaseBase):
@@ -164,6 +176,10 @@ class MarketDetail(_SnakeCaseBase):
     committee: Optional[List[str]] = None  # List of agent IDs on the committee
     resolution_votes: Optional[List[CommitteeVoteDetail]] = None  # Committee votes
     resolution_deadline: Optional[datetime] = None  # 30min after RESOLVING
+    # Computed resolution stage (issue #148)
+    resolution_stage: Optional[ResolutionStage] = None
+    committee_size: Optional[int] = None
+    votes_cast: Optional[int] = None
 
 
 class MarketCreated(_SnakeCaseBase):

--- a/routes/markets.py
+++ b/routes/markets.py
@@ -25,13 +25,50 @@ from models import (
     MarketCreate, MarketSummary, MarketDetail, MarketCreated,
     ProbabilityPoint, MarketHistory,
     CommitteeVoteDetail, CommitteeOutcome,
-    MarketStatus,
+    MarketStatus, ResolutionStage,
     PaginationMeta, PaginatedMarketSummary,
 )
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["markets"])
+
+
+def _compute_resolution_stage(market: dict) -> tuple:
+    """Compute resolution stage, committee_size, and votes_cast for a RESOLVING market.
+
+    Returns (resolution_stage, committee_size, votes_cast).
+    Returns (None, None, None) if market is not RESOLVING.
+    """
+    if market.get("status") != MarketStatus.RESOLVING:
+        return None, None, None
+
+    db = get_db()
+    committee = market.get("committee") or []
+    committee_size = len(committee) if committee else None
+
+    if not committee or len(committee) <= 1:
+        # Solo creator — no committee or just the creator
+        return ResolutionStage.CREATOR_PENDING, committee_size, 0
+
+    # Committee exists — check votes
+    raw_votes = db.get_committee_votes(market["id"])
+    votes_cast = len(raw_votes) if raw_votes else 0
+
+    resolution_deadline = market.get("resolution_deadline")
+    now = datetime.now(timezone.utc)
+    deadline_expired = resolution_deadline and now > resolution_deadline
+
+    if deadline_expired:
+        # Deadline passed — creator can resolve unilaterally
+        return ResolutionStage.COMMITTEE_COMPLETE, committee_size, votes_cast
+
+    if votes_cast < len(committee):
+        # Still waiting for votes
+        return ResolutionStage.COMMITTEE_VOTING, committee_size, votes_cast
+
+    # All votes in but no unanimity (otherwise market would be RESOLVED)
+    return ResolutionStage.COMMITTEE_COMPLETE, committee_size, votes_cast
 
 
 # =============================================================================
@@ -86,6 +123,7 @@ async def list_markets(
 
     result = []
     for m in page:
+        resolution_stage, committee_size, votes_cast = _compute_resolution_stage(m)
         result.append(MarketSummary(
             id=m["id"],
             title=m["title"],
@@ -95,6 +133,10 @@ async def list_markets(
             total_volume=m["total_volume"],
             creator_id=m["creator_id"],
             creator_username=m.get("creator_username"),
+            resolution_stage=resolution_stage,
+            committee_size=committee_size,
+            votes_cast=votes_cast,
+            resolution_deadline=m.get("resolution_deadline"),
         ))
 
     paginated = PaginatedMarketSummary(
@@ -123,6 +165,8 @@ def _build_market_detail(market: dict, creator_username: str = None) -> MarketDe
                 for v in raw_votes
             ]
 
+    resolution_stage, committee_size, votes_cast = _compute_resolution_stage(market)
+
     return MarketDetail(
         id=market["id"],
         title=market["title"],
@@ -141,6 +185,9 @@ def _build_market_detail(market: dict, creator_username: str = None) -> MarketDe
         committee=market.get("committee"),
         resolution_votes=committee_votes_detail,
         resolution_deadline=market.get("resolution_deadline"),
+        resolution_stage=resolution_stage,
+        committee_size=committee_size,
+        votes_cast=votes_cast,
     )
 
 


### PR DESCRIPTION
## Summary

Adds computed resolution status detail to `MarketSummary` and `MarketDetail` API responses, so the frontend can show **why** a market is "Awaiting Resolution" instead of a generic badge.

Closes #148

## Changes

### `models.py`
- New `ResolutionStage` enum: `creator_pending`, `committee_voting`, `committee_complete`
- `MarketSummary` gains: `resolution_stage`, `committee_size`, `votes_cast`, `resolution_deadline`
- `MarketDetail` gains: `resolution_stage`, `committee_size`, `votes_cast`

### `routes/markets.py`
- New `_compute_resolution_stage()` helper that determines the stage:
  - **`creator_pending`** — solo creator or deadline expired, waiting for creator action
  - **`committee_voting`** — committee formed, still collecting votes
  - **`committee_complete`** — all votes in (or expired), no unanimity reached
- Updated `list_markets` to include resolution fields for each RESOLVING market
- Updated `_build_market_detail` to include resolution stage

## API Response Examples

**List view (RESOLVING market):**
```json
{
  "id": "...",
  "status": "RESOLVING",
  "resolution_stage": "committee_voting",
  "committee_size": 3,
  "votes_cast": 1,
  "resolution_deadline": "2025-01-31T16:30:00Z"
}
```

**Detail view adds the same fields alongside existing `committee` and `resolution_votes`.**

## Backward Compatible

All new fields are `Optional` with `None` defaults — no breaking changes for existing clients.
