### PR TITLE
fix: resolve pre-existing CI blockers (lint F401 + missing test field)

### DIFF
--- a/routes/agents.py
+++ b/routes/agents.py
@@ -13,7 +13,6 @@ from cpmm import get_cpmm_probability
 from deps import get_db, STARTING_BALANCE
 from twitter_verify import (
     generate_verification_code,
-    generate_claim_tweet_text,
     is_valid_twitter_url, extract_tweet_id, extract_twitter_handle,
     fetch_tweet, verify_tweet_contains_code,
 )

--- a/test_snake_case.py
+++ b/test_snake_case.py
@@ -120,7 +120,7 @@ RESPONSE_MODELS = {
         probability_before=0.5, probability_after=0.6, created_at=NOW,
     ),
     "LeaderboardEntry": LeaderboardEntry(
-        user_id="u", username="u", pnl=100, total_volume=500, win_rate=0.6,
+        user_id="u", username="u", balance=1000, pnl=100, total_volume=500, win_rate=0.6,
     ),
     "ProbabilityPoint": ProbabilityPoint(
         timestamp=NOW, probability=0.5, volume=100,


### PR DESCRIPTION
## Problem
Two pre-existing issues on main are failing CI for **all 5 open PRs** (4 already approved by @shirtlessfounder):

### 1. Lint: F401 unused import
`routes/agents.py:16` — `generate_claim_tweet_text` imported but never used.

### 2. Test: missing `balance` field
`test_snake_case.py:122` — `LeaderboardEntry` pydantic model requires `balance` field but the test fixture didn't include it.

## Fix
- Removed the unused import (1 line)
- Added `balance=1000` to the test fixture (1 line)

## Verification
- `ruff check routes/agents.py` → All checks passed
- `pytest test_snake_case.py` → 31 passed
- `pytest` (full suite) → 206 passed

## Unblocks
Once merged, these PRs can all go in:
- #142 (heartbeat guide) ✅ Approved
- #143 (consolidate skill.md) ✅ Approved
- #145 (TypeScript SDK) ✅ Approved
- #146 (type hints) ✅ Approved
- #149 (resolution status detail)