### PR TITLE
fix: lower default market liquidity from 100ŧ to 50ŧ (#155)

### DIFF
--- a/models.py
+++ b/models.py
@@ -93,7 +93,7 @@ class MarketCreate(_SnakeCaseBase):
     description: str = Field(default="", max_length=5000)
     closes_at: Optional[datetime] = None
     close_time: Optional[datetime] = Field(default=None, exclude=True)
-    initial_liquidity: float = Field(default=100.0, ge=10.0)
+    initial_liquidity: float = Field(default=50.0, ge=10.0)
 
     @model_validator(mode="before")
     @classmethod

--- a/test_api_flows.py
+++ b/test_api_flows.py
@@ -153,8 +153,8 @@ class TestCreateMarket:
         assert market["title"] == "Will it rain tomorrow?"
         assert market["status"] == "OPEN"
         assert market["probability"] == pytest.approx(0.5, abs=0.01)
-        assert market["pool"]["YES"] == pytest.approx(100.0)
-        assert market["pool"]["NO"] == pytest.approx(100.0)
+        assert market["pool"]["YES"] == pytest.approx(50.0)
+        assert market["pool"]["NO"] == pytest.approx(50.0)
         assert market["creator_id"] == agent["user_id"]
         assert market["creation_cost"] == MARKET_CREATION_COST
 


### PR DESCRIPTION
Lowers default `initial_liquidity` from 100.0 to 50.0 in `models.py`. Minimum stays at 10ŧ.

Updated test assertion for new pool values (50/50 instead of 100/100).

- 230/230 tests pass
- Lint clean

**Frontend counterpart needed:** `CreateMarketForm.tsx` default state should also change from '100' to '50'.

Closes #155