### PR TITLE
feat: auto-transition expired OPEN markets to RESOLVING (#154)

### DIFF
--- a/api.py
+++ b/api.py
@@ -14,6 +14,7 @@ Route handlers live in the ``routes/`` package.  This file wires up:
   - Lifespan (startup / shutdown)
 """
 
+import asyncio
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone, timedelta
@@ -61,6 +62,26 @@ deps.init(db)
 # Lifespan
 # ---------------------------------------------------------------------------
 
+SWEEP_INTERVAL_SECONDS = 60  # Check for expired markets every 60s
+
+
+async def _expired_market_sweep_loop():
+    """Background loop: transition expired OPEN markets to RESOLVING."""
+    from committee import sweep_expired_markets
+    # Brief startup delay to let the app finish initializing
+    await asyncio.sleep(5)
+    logger.info("expired_market_sweep_started", interval=SWEEP_INTERVAL_SECONDS)
+    while True:
+        try:
+            count = sweep_expired_markets()
+            if count > 0:
+                from market_cache import market_cache
+                market_cache.invalidate()
+        except Exception:
+            logger.exception("expired_market_sweep_error")
+        await asyncio.sleep(SWEEP_INTERVAL_SECONDS)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     if not db.get_user("demo-user"):
@@ -68,7 +89,17 @@ async def lifespan(app: FastAPI):
     market_count = db.count_markets()
     user_count = db.count_users()
     logger.info("api_started", market_count=market_count, user_count=user_count)
+
+    # Start background sweep for expired markets (issue #154)
+    sweep_task = asyncio.create_task(_expired_market_sweep_loop())
+
     yield
+
+    sweep_task.cancel()
+    try:
+        await sweep_task
+    except asyncio.CancelledError:
+        pass
     db.close_pool()
     logger.info("api_shutdown")
 

--- a/committee.py
+++ b/committee.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from deps import get_db
+from models import MarketStatus
 
 logger = logging.getLogger(__name__)
 
@@ -84,19 +85,56 @@ def check_committee_unanimity(market_id: str, committee: list) -> Optional[str]:
     return None
 
 
-def maybe_transition_market(market: dict, market_id: str) -> None:
-    """No-op: markets no longer auto-transition based on closes_at.
+def transition_market_to_resolving(market_id: str, market: dict) -> bool:
+    """Transition a single OPEN market to RESOLVING and form its committee.
 
-    Deprecated since issue #115: markets remain OPEN and tradeable until
-    explicitly resolved via POST /markets/{id}/resolve.  The closes_at
-    field is now display-only ("event end time").
+    Returns True if the transition happened, False if skipped.
     """
-    pass
+    db = get_db()
+
+    if market.get("status") != "OPEN":
+        return False
+
+    committee = form_committee(market_id, market)
+    db.update_market_status(market_id, MarketStatus.RESOLVING)
+    market["status"] = MarketStatus.RESOLVING
+
+    logger.info(
+        "Auto-transitioned market %s to RESOLVING (committee: %d members)",
+        market_id, len(committee),
+    )
+    return True
 
 
-def bg_transition_expired_markets() -> None:
-    """No-op: markets no longer auto-transition based on closes_at.
+def sweep_expired_markets() -> int:
+    """Find all OPEN markets past closes_at and transition them to RESOLVING.
 
-    Deprecated since issue #115.
+    Returns the number of markets transitioned.
+    Called periodically by the background sweep task.
     """
-    pass
+    db = get_db()
+    now = datetime.now(timezone.utc)
+    transitioned = 0
+
+    markets = db.list_markets()
+    for m in markets:
+        if m.get("status") != "OPEN":
+            continue
+        closes_at = m.get("closes_at")
+        if not closes_at:
+            continue
+        # Normalize closes_at to datetime if it's a string
+        if isinstance(closes_at, str):
+            closes_at = datetime.fromisoformat(closes_at.replace("Z", "+00:00"))
+        if closes_at.tzinfo is None:
+            closes_at = closes_at.replace(tzinfo=timezone.utc)
+        if now > closes_at:
+            try:
+                transition_market_to_resolving(m["id"], m)
+                transitioned += 1
+            except Exception:
+                logger.exception("Failed to transition market %s", m["id"])
+
+    if transitioned > 0:
+        logger.info("Sweep: transitioned %d expired markets to RESOLVING", transitioned)
+    return transitioned

--- a/scripts/auto_resolve.py
+++ b/scripts/auto_resolve.py
@@ -20,7 +20,7 @@ import os
 import re
 import sys
 from datetime import datetime, timezone
-from typing import Optional, Tuple, Literal
+from typing import Optional, Tuple
 
 import requests
 
@@ -398,7 +398,7 @@ def resolve_market_api(market_id: str, outcome: str, market_status: str = "OPEN"
         error_data = resp.json()
         if error_data.get("code") == "COMMITTEE_WINDOW_ACTIVE":
             # Try committee vote endpoint instead
-            print(f"   📋 Committee window active, casting vote...")
+            print("   📋 Committee window active, casting vote...")
             vote_resp = requests.post(
                 f"{API_BASE}/markets/{market_id}/resolution-vote",
                 json={"outcome": outcome},
@@ -409,7 +409,7 @@ def resolve_market_api(market_id: str, outcome: str, market_status: str = "OPEN"
             if vote_resp.status_code == 200:
                 vote_data = vote_resp.json()
                 if vote_data.get("auto_resolved"):
-                    print(f"   ✅ Committee vote triggered auto-resolution!")
+                    print("   ✅ Committee vote triggered auto-resolution!")
                     return {"status": "RESOLVED", "resolution": outcome}
                 else:
                     # Vote cast but no auto-resolve yet
@@ -467,7 +467,7 @@ def main():
     errors = []
     
     for market in markets:
-        print(f"─" * 60)
+        print("─" * 60)
         print(f"📌 {market['title']}")
         print(f"   ID: {market['id']}")
         print(f"   Closed: {market['closes_at']} ({market.get('_hours_past_close', 0):.1f}h ago)")
@@ -500,7 +500,7 @@ def main():
                     "reasoning": reasoning,
                 })
         else:
-            print(f"   ⚠️ Needs manual resolution")
+            print("   ⚠️ Needs manual resolution")
             print(f"   📝 Reason: {reasoning}")
             manual_needed.append({
                 "id": market["id"],

--- a/test_committee.py
+++ b/test_committee.py
@@ -28,6 +28,7 @@ os.environ.pop("DATABASE_URL", None)
 from api import app, db  # noqa: E402
 from committee import (  # noqa: E402
     COMMITTEE_WINDOW_MINUTES, form_committee, check_committee_unanimity,
+    sweep_expired_markets,
 )
 from models import MarketStatus, Outcome  # noqa: E402
 from rate_limiter import rate_limiter  # noqa: E402
@@ -940,3 +941,86 @@ class TestEdgeCases:
         resp = client.post(f"/markets/{fake_uuid}/resolution-vote",
             json={"outcome": "YES"}, headers=creator["headers"])
         assert resp.status_code == 404
+
+
+# ===========================================================================
+# 6. Auto-Sweep Expired Markets Tests (issue #154)
+# ===========================================================================
+
+class TestSweepExpiredMarkets:
+    """Test the background sweep that transitions expired OPEN → RESOLVING."""
+
+    def test_sweep_transitions_expired_market(self):
+        """Market past closes_at should be transitioned to RESOLVING."""
+        creator = _register_agent(client, "sweep_c")
+        # Create market that closes 1 minute from now, then backdate closes_at
+        market = _create_market(client, creator["headers"], minutes=1)
+        market_id = market["id"]
+
+        # Backdate closes_at to the past
+        m = db.get_market(market_id)
+        m["closes_at"] = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+
+        assert m["status"] == "OPEN"
+        count = sweep_expired_markets()
+        assert count == 1
+
+        m = db.get_market(market_id)
+        assert m["status"] == MarketStatus.RESOLVING
+        assert m.get("committee") is not None
+
+    def test_sweep_ignores_future_market(self):
+        """Market not yet past closes_at should remain OPEN."""
+        creator = _register_agent(client, "sweep_future_c")
+        market = _create_market(client, creator["headers"], minutes=60)
+        market_id = market["id"]
+
+        count = sweep_expired_markets()
+        assert count == 0
+
+        m = db.get_market(market_id)
+        assert m["status"] == "OPEN"
+
+    def test_sweep_ignores_already_resolving(self):
+        """Market already in RESOLVING should not be re-processed."""
+        creator = _register_agent(client, "sweep_resolving_c")
+        market = _create_market(client, creator["headers"], minutes=1)
+        market_id = market["id"]
+
+        # Backdate and force to RESOLVING
+        m = db.get_market(market_id)
+        m["closes_at"] = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        _force_resolving(market_id)
+
+        count = sweep_expired_markets()
+        assert count == 0
+
+    def test_sweep_transitions_multiple_markets(self):
+        """Multiple expired markets should all be transitioned."""
+        creator = _register_agent(client, "sweep_multi_c")
+        past = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        ids = []
+        # Create markets directly in storage to avoid rate limiter
+        for i in range(3):
+            mid = str(uuid.uuid4())
+            db._markets[mid] = {
+                "id": mid,
+                "title": f"Sweep test {i}",
+                "description": "test",
+                "creator_id": creator["user_id"],
+                "status": "OPEN",
+                "closes_at": past,
+                "probability": 0.5,
+                "pool": {"YES": 50.0, "NO": 50.0},
+                "volume": 0.0,
+                "num_traders": 0,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            }
+            ids.append(mid)
+
+        count = sweep_expired_markets()
+        assert count == 3
+
+        for mid in ids:
+            m = db.get_market(mid)
+            assert m["status"] == MarketStatus.RESOLVING


### PR DESCRIPTION
## Problem
Markets stay `OPEN` after `closes_at` passes — they never transition to `RESOLVING` on their own (disabled in issue #115).

## Solution
Background sweep task (60s interval) in the API lifespan that:
1. Queries all `OPEN` markets where `closes_at < now()`
2. Forms a resolution committee via `form_committee()`
3. Transitions to `RESOLVING`
4. Invalidates market cache

### Files changed
| File | What |
|------|------|
| `committee.py` | New `sweep_expired_markets()` + `transition_market_to_resolving()` replacing old no-op stubs |
| `api.py` | Async sweep loop in lifespan, clean cancellation on shutdown |
| `scripts/auto_resolve.py` | Fix 5 pre-existing ruff lint errors (F401, F541) |
| `test_committee.py` | 4 new tests for sweep behavior |

## Tests
- 234/234 pass (4 new sweep tests)
- Lint clean (also fixes the 5 pre-existing ruff errors that were breaking CI on main)

Closes #154