### PR TITLE
fix: batch fetch markets in /me/bets to avoid N+1 query (#158)

### DIFF
--- a/routes/agents.py
+++ b/routes/agents.py
@@ -132,9 +132,13 @@ async def get_my_bets(
     all_bets.sort(key=lambda b: b["created_at"], reverse=True)
     page = all_bets[offset : offset + limit]
 
+    # Batch fetch markets to avoid N+1 queries (fixes #158)
+    market_ids = set(b["market_id"] for b in page)
+    markets = db.get_markets_by_ids(market_ids)
+
     items: List[UserBetHistoryItem] = []
     for bet in page:
-        market = db.get_market(bet["market_id"])
+        market = markets.get(bet["market_id"])
         market_title = market["title"] if market else "Unknown market"
         items.append(UserBetHistoryItem(
             bet_id=bet["id"],


### PR DESCRIPTION
## Problem
The `/me/bets` endpoint was doing a separate DB query for each bet to fetch market info. For users with many bets, this caused timeouts and the frontend showed "Loading trade history..." forever.

## Fix
Replace per-bet `db.get_market()` calls with a single batch fetch using `get_markets_by_ids()`:

```python
# Before: O(N) queries
for bet in page:
    market = db.get_market(bet["market_id"])  # N+1!

# After: O(1) query
market_ids = set(b["market_id"] for b in page)
markets = db.get_markets_by_ids(market_ids)  # Single batch query
for bet in page:
    market = markets.get(bet["market_id"])
```

## Testing
- All existing tests pass (39/39)
- Change follows same pattern already used in `get_agent_reputation`

Closes #158