### PR TITLE
feat: add global comment feed endpoint (#160)

### DIFF
--- a/models.py
+++ b/models.py
@@ -594,6 +594,24 @@ class MarketComments(_SnakeCaseBase):
     total: int
 
 
+class RecentComment(_SnakeCaseBase):
+    """A comment with market context for the global feed (issue #160)."""
+    id: str
+    market_id: str
+    market_title: str  # Title of the market this comment belongs to
+    user_id: str
+    username: str
+    content: str
+    created_at: datetime
+    parent_id: Optional[str] = None
+
+
+class RecentCommentsResponse(_SnakeCaseBase):
+    """Recent comments across all markets."""
+    comments: List[RecentComment]
+    total: int
+
+
 # =============================================================================
 # Committee Resolution Models
 # =============================================================================

--- a/routes/comments.py
+++ b/routes/comments.py
@@ -12,11 +12,46 @@ from deps import get_db
 from utils import validate_uuid
 from errors import error_response, ErrorCode
 from event_bus import event_bus, SSEEvent
-from models import CommentCreate, Comment, MarketComments
+from models import CommentCreate, Comment, MarketComments, RecentComment, RecentCommentsResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["markets"])
+
+
+@router.get("/comments/recent", response_model=RecentCommentsResponse)
+async def get_recent_comments(limit: int = 50):
+    """Get recent comments across all markets (global feed).
+
+    Returns comments from all markets, newest first, with market_title
+    indicating which market each comment belongs to.
+
+    Used for the General Chat panel (issue #160).
+    """
+    db = get_db()
+    # Clamp limit to reasonable bounds
+    limit = max(1, min(limit, 100))
+
+    raw_comments = db.get_recent_comments(limit)
+
+    comments = [
+        RecentComment(
+            id=c["id"],
+            market_id=c["market_id"],
+            market_title=c.get("market_title", "Unknown Market"),
+            user_id=c["user_id"],
+            username=c.get("username", "unknown"),
+            content=c["content"],
+            created_at=c["created_at"],
+            parent_id=c.get("parent_id"),
+        )
+        for c in raw_comments
+    ]
+
+    return RecentCommentsResponse(
+        comments=comments,
+        total=len(comments),
+    )
 
 
 @router.get("/markets/{market_id}/comments", response_model=MarketComments)

--- a/storage/social.py
+++ b/storage/social.py
@@ -75,6 +75,45 @@ class SocialStorageMixin:
         finally:
             self._put_conn(conn)
 
+    def get_recent_comments(self, limit: int = 50) -> List[dict]:
+        """Get recent comments across ALL markets, with market title included.
+
+        Returns dicts with username and market_title fields for display in the
+        global chat panel (issue #160).
+        """
+        if self._use_memory:
+            if not hasattr(self, '_comments'):
+                return []
+            # In-memory: need to join with markets manually
+            comments = sorted(
+                list(self._comments.values()),
+                key=lambda x: x["created_at"],
+                reverse=True
+            )[:limit]
+            # Add market_title if we have access to markets
+            for c in comments:
+                if hasattr(self, '_markets') and c["market_id"] in self._markets:
+                    c["market_title"] = self._markets[c["market_id"]].get("title", "Unknown")
+                else:
+                    c["market_title"] = "Unknown"
+            return comments
+
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT c.*, u.username, m.title as market_title
+                    FROM comments c
+                    JOIN users u ON c.user_id = u.id
+                    JOIN markets m ON c.market_id = m.id
+                    ORDER BY c.created_at DESC
+                    LIMIT %s
+                """, (limit,))
+                rows = cur.fetchall()
+                return [dict(row) for row in rows]
+        finally:
+            self._put_conn(conn)
+
     # --- Resolution Votes ---
 
     def save_resolution_votes(self, market_id: str, votes: List[dict]) -> None:


### PR DESCRIPTION
Closes #160

## Summary
Adds a new endpoint `GET /comments/recent?limit=50` that returns recent comments from ALL markets, with the market title included in each comment. This is for the General Chat panel to show a unified comment feed.

## Changes
- **routes/comments.py**: Added new endpoint with limit parameter (1-100, default 50)
- **storage/social.py**: Added `get_recent_comments()` method that JOINs comments with markets table to get market_title
- **models.py**: Added `RecentComment` and `RecentCommentsResponse` models

## API
```
GET /comments/recent?limit=50

Response:
{
  "comments": [
    {
      "id": "...",
      "market_id": "...",
      "market_title": "Will BTC hit 100k?",
      "user_id": "...",
      "username": "bicep",
      "content": "Nice market!",
      "created_at": "2026-02-03T02:30:00Z",
      "parent_id": null
    }
  ],
  "total": 1
}
```

## Testing
All 234 tests pass.