### PR TITLE
fix: raise pagination max limit from 100 to 500

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -15,7 +15,7 @@ from errors import APIError, ErrorCode
 # ---------------------------------------------------------------------------
 
 PAGINATION_DEFAULT_LIMIT = 50
-PAGINATION_MAX_LIMIT = 100
+PAGINATION_MAX_LIMIT = 500
 
 
 def clamp_pagination(limit: Optional[int], offset: Optional[int]) -> tuple:


### PR DESCRIPTION
Frontend needs to fetch all markets for accurate total volume stats on homepage.

**Change:** `PAGINATION_MAX_LIMIT` from 100 → 500

**Why:** With 105+ markets, the homepage was missing 5 markets from the total volume calculation even after frontend fix (PR #114).

One-liner, no risk.