### PR TITLE
perf: eliminate duplicate get_committee_votes query in market detail

### DIFF
--- a/routes/markets.py
+++ b/routes/markets.py
@@ -36,8 +36,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["markets"])
 
 
-def _compute_resolution_stage(market: dict) -> tuple:
+def _compute_resolution_stage(market: dict, preloaded_votes: list = None) -> tuple:
     """Compute resolution stage, committee_size, and votes_cast for a RESOLVING market.
+
+    Args:
+        market: Market dict from database
+        preloaded_votes: Optional preloaded committee votes to avoid duplicate query.
+                        If None, will fetch from DB.
 
     Returns (resolution_stage, committee_size, votes_cast).
     Returns (None, None, None) if market is not RESOLVING.
@@ -45,7 +50,6 @@ def _compute_resolution_stage(market: dict) -> tuple:
     if market.get("status") != MarketStatus.RESOLVING:
         return None, None, None
 
-    db = get_db()
     committee = market.get("committee") or []
     committee_size = len(committee) if committee else None
 
@@ -53,8 +57,12 @@ def _compute_resolution_stage(market: dict) -> tuple:
         # Solo creator — no committee or just the creator
         return ResolutionStage.CREATOR_PENDING, committee_size, 0
 
-    # Committee exists — check votes
-    raw_votes = db.get_committee_votes(market["id"])
+    # Committee exists — check votes (use preloaded if available)
+    if preloaded_votes is not None:
+        raw_votes = preloaded_votes
+    else:
+        db = get_db()
+        raw_votes = db.get_committee_votes(market["id"])
     votes_cast = len(raw_votes) if raw_votes else 0
 
     resolution_deadline = market.get("resolution_deadline")
@@ -195,7 +203,9 @@ def _build_market_detail(market: dict, creator_username: str = None, include: st
     market_id = market["id"]
     
     # Build committee vote details if committee exists
+    # Fetch once and reuse for resolution_stage computation (fixes duplicate query)
     committee_votes_detail = None
+    raw_votes = []
     if market.get("committee"):
         raw_votes = db.get_committee_votes(market_id)
         if raw_votes:
@@ -208,7 +218,8 @@ def _build_market_detail(market: dict, creator_username: str = None, include: st
                 for v in raw_votes
             ]
 
-    resolution_stage, committee_size, votes_cast = _compute_resolution_stage(market)
+    # Pass preloaded votes to avoid duplicate DB query
+    resolution_stage, committee_size, votes_cast = _compute_resolution_stage(market, preloaded_votes=raw_votes)
     
     # Parse include param
     include_set = set(include.lower().split(",")) if include else set()


### PR DESCRIPTION
## Problem
The `/markets/{id}` endpoint was taking 2.2+ seconds (compared to 680ms for `/markets` list).

## Root Cause
`get_committee_votes()` was called **twice** per request:
1. In `_build_market_detail()` to build `committee_votes_detail`
2. In `_compute_resolution_stage()` to calculate resolution stage

This duplicate DB roundtrip added unnecessary latency, especially for RESOLVING markets with committees.

## Fix
- Add optional `preloaded_votes` parameter to `_compute_resolution_stage()`
- Pass preloaded votes from `_build_market_detail()` to avoid the duplicate query
- Falls back to fetching from DB when called from `list_markets` (which doesn't preload)

## Testing
- `python3 -m py_compile routes/markets.py` passes
- No functional changes — same data returned, just fewer queries

## Expected Improvement
Eliminates 1 DB roundtrip per market detail request. Combined with Railway's cross-region DB latency (~200-400ms), this should reduce response time by that amount.

---
-bicep