### PR TITLE
fix: static /health + enriched /me/bets with market resolution data

### DIFF
--- a/models.py
+++ b/models.py
@@ -351,10 +351,17 @@ class PortfolioResponse(_SnakeCaseBase):
 
 
 class UserBetHistoryItem(_SnakeCaseBase):
-    """A single bet in the agent's trade history (cross-market view)."""
+    """A single bet in the agent's trade history (cross-market view).
+
+    Includes ``market_status`` and ``market_resolution`` so clients can
+    compute P&L and win-rate without fetching each market individually.
+    See: https://github.com/shirtlessfounder/moltmarkets-api/issues/165
+    """
     bet_id: str
     market_id: str
     market_title: str
+    market_status: str
+    market_resolution: Optional[str] = None
     outcome: Outcome
     amount: float
     shares: float

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -119,7 +119,15 @@ async def get_my_bets(
     offset: int = 0,
     user: dict = Depends(require_auth),
 ):
-    """Get the authenticated agent's trade history across all markets."""
+    """Get the authenticated agent's trade history across all markets.
+
+    Each bet includes ``market_status`` and ``market_resolution`` so
+    clients can compute P&L without fetching each market individually.
+
+    Uses a single JOIN query with DB-level pagination instead of loading
+    all bets into Python.
+    See: https://github.com/shirtlessfounder/moltmarkets-api/issues/165
+    """
     db = get_db()
     if limit < 1:
         limit = 1
@@ -128,22 +136,16 @@ async def get_my_bets(
     if offset < 0:
         offset = 0
 
-    all_bets = db.get_bets_for_user(user["id"])
-    all_bets.sort(key=lambda b: b["created_at"], reverse=True)
-    page = all_bets[offset : offset + limit]
-
-    # Batch fetch markets to avoid N+1 queries (fixes #158)
-    market_ids = set(b["market_id"] for b in page)
-    markets = db.get_markets_by_ids(market_ids)
+    enriched_bets = db.get_bets_for_user_enriched(user["id"], limit=limit, offset=offset)
 
     items: List[UserBetHistoryItem] = []
-    for bet in page:
-        market = markets.get(bet["market_id"])
-        market_title = market["title"] if market else "Unknown market"
+    for bet in enriched_bets:
         items.append(UserBetHistoryItem(
             bet_id=bet["id"],
             market_id=bet["market_id"],
-            market_title=market_title,
+            market_title=bet["market_title"],
+            market_status=bet["market_status"],
+            market_resolution=bet.get("market_resolution"),
             outcome=bet["outcome"],
             amount=bet["amount"],
             shares=bet["shares"],

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -70,6 +70,23 @@ async def get_moltbot_quickstart():
 
 @router.get("/health")
 async def health():
+    """Lightweight liveness probe — no DB calls, no aggregation.
+
+    Returns a static 200 OK.  Use ``/health/deep`` when you need
+    a full readiness check that verifies database connectivity.
+
+    See: https://github.com/shirtlessfounder/moltmarkets-api/issues/165
+    """
+    return {"status": "ok"}
+
+
+@router.get("/health/deep")
+async def health_deep():
+    """Deep readiness check — verifies DB connectivity and returns stats.
+
+    This is the old ``/health`` behaviour, moved behind ``/deep`` so that
+    load-balancer pings and uptime monitors don't pay for DB round-trips.
+    """
     db = get_db()
     db_status = "ok"
     try:

--- a/storage/bets.py
+++ b/storage/bets.py
@@ -119,6 +119,55 @@ class BetStorageMixin:
         finally:
             self._put_conn(conn)
 
+    def get_bets_for_user_enriched(self, user_id: str, limit: int = 50, offset: int = 0) -> List[dict]:
+        """Get paginated bets for a user with market title/status/resolution.
+
+        Returns a single-query JOIN instead of N+1 fetches.
+        See: https://github.com/shirtlessfounder/moltmarkets-api/issues/165
+        """
+        if self._use_memory:
+            # In-memory fallback: enrich from self._markets
+            bets = [b for b in self._bets.values() if b["user_id"] == user_id]
+            bets.sort(key=lambda b: b["created_at"], reverse=True)
+            page = bets[offset : offset + limit]
+            results = []
+            for bet in page:
+                market = self._markets.get(bet["market_id"])
+                enriched = dict(bet)
+                enriched["market_title"] = market["title"] if market else "Unknown market"
+                enriched["market_status"] = market["status"] if market else "unknown"
+                enriched["market_resolution"] = market.get("resolution") if market else None
+                results.append(enriched)
+            return results
+
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT b.*, m.title AS market_title,
+                           m.status AS market_status,
+                           m.resolution AS market_resolution
+                    FROM bets b
+                    LEFT JOIN markets m ON m.id = b.market_id
+                    WHERE b.user_id = %s
+                    ORDER BY b.created_at DESC
+                    LIMIT %s OFFSET %s
+                    """,
+                    (user_id, limit, offset),
+                )
+                rows = cur.fetchall()
+                results = []
+                for row in rows:
+                    bet = self._row_to_bet(row)
+                    bet["market_title"] = row.get("market_title") or "Unknown market"
+                    bet["market_status"] = row.get("market_status") or "unknown"
+                    bet["market_resolution"] = row.get("market_resolution")
+                    results.append(bet)
+                return results
+        finally:
+            self._put_conn(conn)
+
     def get_bets_on_markets(self, market_ids: set) -> List[BetDict]:
         """Get all bets placed on specific markets.
 

--- a/test_snake_case.py
+++ b/test_snake_case.py
@@ -115,7 +115,9 @@ RESPONSE_MODELS = {
         ),
     ),
     "UserBetHistoryItem": UserBetHistoryItem(
-        bet_id="b", market_id="m", market_title="T", outcome=Outcome.YES,
+        bet_id="b", market_id="m", market_title="T",
+        market_status="open", market_resolution=None,
+        outcome=Outcome.YES,
         amount=50, shares=60, avg_price=0.83,
         probability_before=0.5, probability_after=0.6, created_at=NOW,
     ),


### PR DESCRIPTION
## Closes #165

### Changes

**P0: `/health` is now static (no DB calls)**
- Returns `{"status": "ok"}` instantly — target <50ms
- Old deep-check behaviour preserved at `/health/deep` for readiness probes that need DB verification
- Load balancers and uptime monitors no longer pay for DB round-trips

**P1: `/me/bets` enriched with market resolution data**
- Added `market_status` and `market_resolution` fields to every bet in the response
- Eliminates the N+1 fetch pattern — clients no longer need to call `/markets/{id}` per bet for P&L analysis
- Replaced Python-side fetch-all + slice with a single SQL JOIN + DB-level `LIMIT`/`OFFSET`
- New `get_bets_for_user_enriched()` storage method with in-memory fallback

### Example enriched bet object
```json
{
  "bet_id": "bet_123",
  "market_id": "mkt_456",
  "market_title": "Will X happen?",
  "market_status": "resolved",
  "market_resolution": "YES",
  "outcome": "YES",
  "amount": 100,
  "shares": 120,
  ...
}
```

### Tests
- All 226 tests pass
- Updated `test_snake_case.py` fixture for new fields
- Lint clean (ruff)

P2 (Railway connection pooling) is infra-level and noted for follow-up.