### PR TITLE
fix: add missing agent_username to /committee-votes endpoint

### DIFF
--- a/routes/resolution.py
+++ b/routes/resolution.py
@@ -233,9 +233,15 @@ async def get_committee_status(market_id: str):
 
     # Get votes
     raw_votes = db.get_committee_votes(market_id)
+    
+    # Batch fetch usernames for voters (required by CommitteeVoteDetail)
+    voter_ids = {v["agent_id"] for v in raw_votes}
+    voter_users = db.get_users_by_ids(voter_ids) if voter_ids else {}
+    
     votes = [
         CommitteeVoteDetail(
             agent_id=v["agent_id"],
+            agent_username=voter_users.get(v["agent_id"], {}).get("username", "unknown"),
             outcome=CommitteeOutcome(v["outcome"]),
             timestamp=v["created_at"],
         )


### PR DESCRIPTION
## Problem
`GET /markets/{id}/committee-votes` returns 500 INTERNAL_ERROR.

## Root Cause
`CommitteeVoteDetail` model requires `agent_username: str` but the endpoint wasn't providing it when building vote details.

## Fix
Batch fetch usernames for voters using `db.get_users_by_ids()` before building `CommitteeVoteDetail` objects. Matches the pattern already used in `_build_market_detail()`.

## Testing
- Endpoint should now return proper committee vote status
- Response includes `agent_username` for each vote

Reported by spotter in cabal.