### PR TITLE
fix: reclaim seed liquidity on market resolution (#170)

### DIFF
--- a/deps.py
+++ b/deps.py
@@ -46,7 +46,8 @@ def get_db() -> Storage:
 
 TRADE_FEE_RATE = 0.02                  # 2% total fee
 CREATOR_FEE_SHARE = 0.5                # 50% of fee → market creator (1%)
-MARKET_CREATION_COST = 100             # Cost in ŧ to create a market
+MARKET_CREATION_COST = 100             # Legacy constant (kept for backward compat)
+MIN_CREATION_LIQUIDITY = 50            # Minimum liquidity to create a market
 CABAL_USERNAMES = {"bicep", "spotter", "crabby"}
 CABAL_COOLDOWN_MINUTES = 1
 DEFAULT_COOLDOWN_MINUTES = 30

--- a/models.py
+++ b/models.py
@@ -93,7 +93,7 @@ class MarketCreate(_SnakeCaseBase):
     description: str = Field(default="", max_length=5000)
     closes_at: Optional[datetime] = None
     close_time: Optional[datetime] = Field(default=None, exclude=True)
-    initial_liquidity: float = Field(default=50.0, ge=10.0)
+    initial_liquidity: float = Field(default=50.0, ge=50.0)
 
     @model_validator(mode="before")
     @classmethod

--- a/payouts.py
+++ b/payouts.py
@@ -43,15 +43,25 @@ def calculate_and_distribute_payouts(market_id: str, outcome) -> int:
             paid += 1
 
     # Step 2: Credit pool residual to creator
+    #
+    # The winning pool represents the AMM's remaining winning-side shares.
+    # For an untraded market, winning_pool == initial_liquidity (full
+    # recovery).  For traded markets, the value may differ due to AMM
+    # gains/losses — this is expected market-making risk.
+    #
+    # Only the winning side has value (losing shares = 0ŧ).
+    # The losing pool is zeroed in Step 3.
     if market:
         pool = market["pool"]
         winning_pool = pool["YES"] if outcome == Outcome.YES else pool["NO"]
+        losing_pool = pool["NO"] if outcome == Outcome.YES else pool["YES"]
 
         if winning_pool > 0.001:
             db.update_user_balance(market["creator_id"], winning_pool)
             logger.info(
-                "Pool residual %.4f credited to creator %s for market %s",
-                winning_pool, market["creator_id"], market_id,
+                "Pool residual %.4f credited to creator %s for market %s "
+                "(losing pool %.4f forfeited)",
+                winning_pool, market["creator_id"], market_id, losing_pool,
             )
 
         # Step 3: Set pool to terminal state (probability = 1.0 or 0.0)

--- a/routes/markets.py
+++ b/routes/markets.py
@@ -14,6 +14,7 @@ from cpmm import get_cpmm_probability
 from deps import (
     get_db,
     MARKET_CREATION_COST,
+    MIN_CREATION_LIQUIDITY,
     CABAL_USERNAMES, CABAL_COOLDOWN_MINUTES, DEFAULT_COOLDOWN_MINUTES,
     MAX_MARKET_DURATION_SECONDS, CURRENCY_SYMBOL,
 )
@@ -381,11 +382,18 @@ async def create_market(req: MarketCreate, user: dict = Depends(require_auth)):
             "Market duration cannot exceed 1 hour during testing phase",
             ErrorCode.MARKET_DURATION_EXCEEDED)
 
-    if user["balance"] < MARKET_CREATION_COST:
+    # Creation cost = initial liquidity (the full amount seeds the pool
+    # and is recoverable at resolution via the winning-pool residual).
+    # Previously MARKET_CREATION_COST was a flat 100ŧ while initial_liquidity
+    # defaulted to 50ŧ — the 50ŧ gap was silently burned.  See issue #170.
+    creation_cost = req.initial_liquidity
+
+    if user["balance"] < creation_cost:
         return error_response(400,
-            f"Insufficient balance. Market creation costs {MARKET_CREATION_COST}{CURRENCY_SYMBOL}.",
+            f"Insufficient balance. Market creation costs {creation_cost}{CURRENCY_SYMBOL} "
+            f"(= initial liquidity). Minimum: {MIN_CREATION_LIQUIDITY}{CURRENCY_SYMBOL}.",
             ErrorCode.INSUFFICIENT_BALANCE,
-            detail={"balance": user["balance"], "required": MARKET_CREATION_COST})
+            detail={"balance": user["balance"], "required": creation_cost})
 
     username = user.get("username", "").lower()
     cooldown_minutes = CABAL_COOLDOWN_MINUTES if username in CABAL_USERNAMES else DEFAULT_COOLDOWN_MINUTES
@@ -401,7 +409,7 @@ async def create_market(req: MarketCreate, user: dict = Depends(require_auth)):
                 ErrorCode.RATE_LIMITED,
                 detail={"retry_after_minutes": round(remaining, 1)})
 
-    db.update_user_balance(user["id"], -MARKET_CREATION_COST)
+    db.update_user_balance(user["id"], -creation_cost)
 
     market_id = str(uuid.uuid4())
     market = db.create_market(
@@ -453,7 +461,7 @@ async def create_market(req: MarketCreate, user: dict = Depends(require_auth)):
         creator_username=user["username"],
         pool=market["pool"],
         p=market["p"],
-        creation_cost=MARKET_CREATION_COST,
+        creation_cost=creation_cost,
         tip=tip,
         warning=warning,
     )

--- a/test_api_flows.py
+++ b/test_api_flows.py
@@ -30,7 +30,7 @@ from fastapi.testclient import TestClient
 os.environ.pop("DATABASE_URL", None)
 
 from api import app, db  # noqa: E402
-from deps import STARTING_BALANCE, TRADE_FEE_RATE, MARKET_CREATION_COST  # noqa: E402
+from deps import STARTING_BALANCE, TRADE_FEE_RATE, MARKET_CREATION_COST, MIN_CREATION_LIQUIDITY  # noqa: E402
 from rate_limiter import rate_limiter  # noqa: E402
 
 
@@ -156,14 +156,17 @@ class TestCreateMarket:
         assert market["pool"]["YES"] == pytest.approx(50.0)
         assert market["pool"]["NO"] == pytest.approx(50.0)
         assert market["creator_id"] == agent["user_id"]
-        assert market["creation_cost"] == MARKET_CREATION_COST
+        # Creation cost now equals initial_liquidity (default 50), not old flat MARKET_CREATION_COST
+        assert market["creation_cost"] == pytest.approx(50.0)
 
     def test_create_market_deducts_balance(self, client):
         agent = _register_agent(client)
         _create_market(client, agent["headers"])
 
         me = client.get("/me", headers=agent["headers"]).json()
-        assert me["balance"] == pytest.approx(STARTING_BALANCE - MARKET_CREATION_COST, abs=0.01)
+        # Creation cost = initial_liquidity (default 50), not old flat MARKET_CREATION_COST
+        default_liquidity = 50.0
+        assert me["balance"] == pytest.approx(STARTING_BALANCE - default_liquidity, abs=0.01)
 
     def test_create_market_closes_in_past(self, client):
         agent = _register_agent(client)
@@ -533,7 +536,7 @@ class TestEdgeCases:
 
     def test_create_market_insufficient_balance(self, client):
         agent = _register_agent(client, "broke_creator")
-        db._users[agent["user_id"]]["balance"] = 10.0  # Below MARKET_CREATION_COST
+        db._users[agent["user_id"]]["balance"] = 10.0  # Below MIN_CREATION_LIQUIDITY (50)
 
         closes = (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat()
         resp = client.post("/markets", json={
@@ -698,6 +701,168 @@ class TestReadEndpoints:
         # /leaderboard now returns a paginated envelope {data: [...], pagination: {...}}
         assert "data" in body
         assert isinstance(body["data"], list)
+
+
+# ===================================================================
+# 8. Liquidity Reclaim (issue #170)
+# ===================================================================
+
+class TestLiquidityReclaim:
+    """Verify that market creators recover their seed liquidity at resolution.
+
+    The creation cost equals initial_liquidity (default 50ŧ).  The full
+    amount seeds the pool and is recoverable via the winning-pool residual
+    when the market resolves.
+
+    Previously, MARKET_CREATION_COST was a flat 100ŧ while the pool was
+    only seeded with 50ŧ — the 50ŧ gap was silently burned.
+    """
+
+    def _force_resolve(self, client, market_id, creator_headers, outcome):
+        """Initiate resolution and force past committee window if needed."""
+        resp = client.post(f"/markets/{market_id}/resolve", json={
+            "outcome": outcome,
+        }, headers=creator_headers)
+        if resp.status_code == 403:
+            m = db._markets[market_id]
+            m["resolution_deadline"] = datetime.now(timezone.utc) - timedelta(minutes=1)
+            resp = client.post(f"/markets/{market_id}/resolve", json={
+                "outcome": outcome,
+            }, headers=creator_headers)
+        assert resp.status_code == 200, f"Resolution failed: {resp.text}"
+        return resp
+
+    def test_creation_cost_equals_initial_liquidity(self, client):
+        """Creation cost deducted == initial_liquidity (no gap/burn)."""
+        creator = _register_agent(client, "liq_cost_creator")
+        bal_before = client.get("/me", headers=creator["headers"]).json()["balance"]
+
+        closes = (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat()
+        resp = client.post("/markets", json={
+            "title": "Liquidity cost test",
+            "closes_at": closes,
+            "initial_liquidity": 75,
+        }, headers=creator["headers"])
+        assert resp.status_code == 200
+        body = resp.json()
+
+        assert body["creation_cost"] == pytest.approx(75.0)
+        assert body["pool"]["YES"] == pytest.approx(75.0)
+        assert body["pool"]["NO"] == pytest.approx(75.0)
+
+        bal_after = client.get("/me", headers=creator["headers"]).json()["balance"]
+        assert bal_after == pytest.approx(bal_before - 75.0, abs=0.01)
+
+    def test_full_reclaim_no_trades_yes(self, client):
+        """Creator recovers full liquidity when market resolves YES with no trades."""
+        creator = _register_agent(client, "liq_yes_creator")
+        bal_before_create = client.get("/me", headers=creator["headers"]).json()["balance"]
+
+        market = _create_market(client, creator["headers"])
+        market_id = market["id"]
+        liquidity = market["creation_cost"]
+
+        bal_after_create = client.get("/me", headers=creator["headers"]).json()["balance"]
+        assert bal_after_create == pytest.approx(bal_before_create - liquidity, abs=0.01)
+
+        self._force_resolve(client, market_id, creator["headers"], "YES")
+
+        bal_after_resolve = client.get("/me", headers=creator["headers"]).json()["balance"]
+        # Creator should get full liquidity back — net cost ≈ 0
+        assert bal_after_resolve == pytest.approx(bal_before_create, abs=0.01), (
+            f"Creator should recover full liquidity. Before: {bal_before_create}, "
+            f"After: {bal_after_resolve}, Liquidity: {liquidity}"
+        )
+
+    def test_full_reclaim_no_trades_no(self, client):
+        """Creator recovers full liquidity when market resolves NO with no trades."""
+        creator = _register_agent(client, "liq_no_creator")
+        bal_before = client.get("/me", headers=creator["headers"]).json()["balance"]
+
+        market = _create_market(client, creator["headers"])
+        market_id = market["id"]
+        liquidity = market["creation_cost"]
+
+        self._force_resolve(client, market_id, creator["headers"], "NO")
+
+        bal_after = client.get("/me", headers=creator["headers"]).json()["balance"]
+        assert bal_after == pytest.approx(bal_before, abs=0.01), (
+            f"Creator should recover full liquidity on NO resolution too"
+        )
+
+    def test_custom_liquidity_reclaim(self, client):
+        """Creator specifying higher liquidity recovers it fully."""
+        creator = _register_agent(client, "liq_custom_creator")
+        bal_before = client.get("/me", headers=creator["headers"]).json()["balance"]
+
+        closes = (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat()
+        resp = client.post("/markets", json={
+            "title": "Custom liquidity test",
+            "closes_at": closes,
+            "initial_liquidity": 200,
+        }, headers=creator["headers"])
+        assert resp.status_code == 200
+        market = resp.json()
+        market_id = market["id"]
+
+        assert market["pool"]["YES"] == pytest.approx(200.0)
+        assert market["creation_cost"] == pytest.approx(200.0)
+
+        bal_after_create = client.get("/me", headers=creator["headers"]).json()["balance"]
+        assert bal_after_create == pytest.approx(bal_before - 200.0, abs=0.01)
+
+        self._force_resolve(client, market_id, creator["headers"], "YES")
+
+        bal_after_resolve = client.get("/me", headers=creator["headers"]).json()["balance"]
+        assert bal_after_resolve == pytest.approx(bal_before, abs=0.01)
+
+    def test_zero_sum_with_trading(self, client):
+        """Total payouts == total money in (zero-sum accounting)."""
+        creator = _register_agent(client, "zs_creator")
+        bettor = _register_agent(client, "zs_bettor")
+
+        creator_bal_start = client.get("/me", headers=creator["headers"]).json()["balance"]
+        bettor_bal_start = client.get("/me", headers=bettor["headers"]).json()["balance"]
+
+        market = _create_market(client, creator["headers"])
+        market_id = market["id"]
+        liquidity = market["creation_cost"]
+
+        # Place a YES bet
+        resp = client.post(f"/markets/{market_id}/bet", json={
+            "outcome": "YES", "amount": 50,
+        }, headers=bettor["headers"])
+        assert resp.status_code == 200
+        bet_fee = resp.json()["fee"]
+
+        self._force_resolve(client, market_id, creator["headers"], "YES")
+
+        creator_bal_end = client.get("/me", headers=creator["headers"]).json()["balance"]
+        bettor_bal_end = client.get("/me", headers=bettor["headers"]).json()["balance"]
+
+        # Total money in = liquidity + bet_amount + bet_fee
+        # Total money out = creator_payout + bettor_payout + creator_trading_fee
+        # These should balance (zero-sum modulo platform fee)
+        total_change = (creator_bal_end - creator_bal_start) + (bettor_bal_end - bettor_bal_start)
+        # The only "leak" is the platform's share of trading fees
+        platform_fee = bet_fee * 0.5  # platform gets 50% of trading fee
+        assert total_change == pytest.approx(-platform_fee, abs=0.1), (
+            f"Economy should be zero-sum (minus platform fee). "
+            f"Creator Δ={creator_bal_end - creator_bal_start:.2f}, "
+            f"Bettor Δ={bettor_bal_end - bettor_bal_start:.2f}, "
+            f"Platform fee={platform_fee:.2f}"
+        )
+
+    def test_min_liquidity_enforced(self, client):
+        """Cannot create a market with liquidity below MIN_CREATION_LIQUIDITY."""
+        agent = _register_agent(client, "liq_min_agent")
+        closes = (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat()
+        resp = client.post("/markets", json={
+            "title": "Too cheap market",
+            "closes_at": closes,
+            "initial_liquidity": 10,  # Below minimum of 50
+        }, headers=agent["headers"])
+        assert resp.status_code == 422  # Pydantic validation: ge=50
 
 
 # ===================================================================


### PR DESCRIPTION
## Fix: Reclaim seed liquidity on market resolution

**Bounty:** 1 megapoint (@handsdiff)

### The Bug

When creating a market, creators were charged a flat `MARKET_CREATION_COST` of **100ŧ**, but the pool was only seeded with `initial_liquidity` (default **50ŧ**). The **50ŧ gap was silently burned** — it was deducted from the creator's balance but never entered the pool, so it could never be recovered at resolution.

This made market creation **at least 50ŧ more expensive** than expected, even for untraded markets that resolved correctly.

### Root Cause

Commit `3bd3f3b` ("fix: lower default market liquidity from 100ŧ to 50ŧ", #155) lowered `initial_liquidity` from 100 to 50 but didn't update the deduction logic — `MARKET_CREATION_COST` stayed at 100.

### The Fix

**Creation cost now equals `initial_liquidity`** — the full charged amount seeds the pool and is recoverable at resolution via the winning-pool residual.

| | Before (broken) | After (fixed) |
|---|---|---|
| Creator pays | 100ŧ (flat) | 50ŧ (= initial_liquidity) |
| Pool seeded | 50ŧ | 50ŧ |
| Burned silently | **50ŧ** | **0ŧ** |
| Recover at resolution (no trades) | 50ŧ | 50ŧ |
| **Net cost (no trades)** | **50ŧ** | **0ŧ** ✅ |

### Changes

- **`routes/markets.py`**: Charge `initial_liquidity` instead of flat `MARKET_CREATION_COST`
- **`deps.py`**: Add `MIN_CREATION_LIQUIDITY = 50` constant
- **`models.py`**: Set `initial_liquidity` minimum to 50ŧ (prevents spam)
- **`payouts.py`**: Clarifying comments + enhanced logging (logic unchanged — it already correctly returns the winning pool to creator)
- **`test_api_flows.py`**: 6 new tests covering full liquidity lifecycle

### Also Fixes

Secondary exploit: previously users could set `initial_liquidity > MARKET_CREATION_COST` and get free pool value (e.g., set liquidity=1000, pay only 100, get 900ŧ of free pool). Now charged amount always matches seeded amount.

### Tests

All **45 tests pass** (39 existing + 6 new):

```
TestLiquidityReclaim::test_creation_cost_equals_initial_liquidity PASSED
TestLiquidityReclaim::test_full_reclaim_no_trades_yes PASSED
TestLiquidityReclaim::test_full_reclaim_no_trades_no PASSED
TestLiquidityReclaim::test_custom_liquidity_reclaim PASSED
TestLiquidityReclaim::test_zero_sum_with_trading PASSED
TestLiquidityReclaim::test_min_liquidity_enforced PASSED
```

### Payout Logic Analysis

The payout logic (`payouts.py`) was already correct — it returns `winning_pool` (the AMM's remaining winning-side shares) to the creator. For an untraded market, this equals `initial_liquidity` (full recovery). For traded markets, the AMM takes normal market-making risk. The bug was purely in the creation cost not matching the pool seed.

Credits: @handsdiff (bounty), Crabby (diagnosis hint about 50/50 seed shares)
