### PR TITLE
feat: disputed state with arbiter voting system

### DIFF
--- a/migrations/011_bounty_disputes.sql
+++ b/migrations/011_bounty_disputes.sql
@@ -1,0 +1,15 @@
+-- migrations/011_bounty_disputes.sql
+-- Bounty dispute resolution (issue #180 phase 2)
+
+ALTER TABLE bounties ADD COLUMN IF NOT EXISTS disputed_at TIMESTAMPTZ;
+
+CREATE TABLE IF NOT EXISTS bounty_votes (
+    bounty_id UUID NOT NULL REFERENCES bounties(id),
+    voter_id VARCHAR(255) NOT NULL REFERENCES users(id),
+    vote VARCHAR(20) NOT NULL CHECK (vote IN ('creator', 'claimant')),
+    reason TEXT DEFAULT '',
+    voted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (bounty_id, voter_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bounty_votes_bounty ON bounty_votes(bounty_id);

--- a/models.py
+++ b/models.py
@@ -849,6 +849,7 @@ class TransferResponse(_SnakeCaseBase):
 class BountyStatus(str, Enum):
     OPEN = "open"            # Accepting claims
     CLAIMED = "claimed"      # An agent is working on it
+    DISPUTED = "disputed"    # Creator disputes, awaiting proof/arbiter
     COMPLETED = "completed"  # Work done, payment released
     CANCELLED = "cancelled"  # Creator cancelled / expired
 
@@ -878,6 +879,7 @@ class BountyResponse(_SnakeCaseBase):
     claimant_username: Optional[str] = None
     created_at: datetime
     claimed_at: Optional[datetime] = None
+    disputed_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     cancelled_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
@@ -897,3 +899,37 @@ class BountySummary(_SnakeCaseBase):
     created_at: datetime
     expires_at: Optional[datetime] = None
     currency: str = "ŧ"
+
+
+class ProofSubmission(_SnakeCaseBase):
+    """Proof of work submission for disputed bounties."""
+    links: List[str] = Field(default_factory=list, max_items=10,
+                             description="URLs to work evidence (PRs, commits, docs)")
+    description: str = Field(..., min_length=10, max_length=5000,
+                             description="Explanation of work completed")
+    progress_percent: int = Field(100, ge=0, le=100,
+                                  description="Self-reported completion percentage")
+
+
+class VoteChoice(str, Enum):
+    """Arbiter vote options."""
+    CREATOR = "creator"    # Side with creator → cancel bounty
+    CLAIMANT = "claimant"  # Side with claimant → release bounty
+
+
+class VoteRequest(_SnakeCaseBase):
+    """Arbiter vote on a disputed bounty."""
+    vote: VoteChoice = Field(..., description="Who to side with: creator or claimant")
+    reason: str = Field("", max_length=1000, description="Optional reason for vote")
+
+
+class VoteResponse(_SnakeCaseBase):
+    """Vote result."""
+    bounty_id: str
+    voter_id: str
+    voter_username: Optional[str] = None
+    vote: VoteChoice
+    reason: str = ""
+    voted_at: datetime
+    votes_so_far: int = Field(..., description="Total votes cast for this bounty")
+    votes_needed: int = Field(3, description="Votes needed for resolution")

--- a/models.py
+++ b/models.py
@@ -933,3 +933,8 @@ class VoteResponse(_SnakeCaseBase):
     voted_at: datetime
     votes_so_far: int = Field(..., description="Total votes cast for this bounty")
     votes_needed: int = Field(3, description="Votes needed for resolution")
+
+
+class ContestRequest(_SnakeCaseBase):
+    """Request to contest (reject) submitted proof. Creator only."""
+    reason: str = Field("", max_length=1000, description="Why the proof is rejected")

--- a/routes/bounties.py
+++ b/routes/bounties.py
@@ -24,7 +24,7 @@ from deps import get_db
 from errors import error_response, ErrorCode
 from models import (
     BountyCreate, BountyResponse, BountySummary, BountyStatus,
-    ProofSubmission, VoteRequest, VoteResponse, VoteChoice,
+    ProofSubmission, VoteRequest, VoteResponse, VoteChoice, ContestRequest,
 )
 from utils import validate_uuid
 
@@ -403,10 +403,49 @@ async def submit_proof(bounty_id: str, proof: ProofSubmission, user: dict = Depe
 
 
 # =============================================================================
-# Vote (arbiter votes on disputed bounty)
+# Contest (creator rejects proof, requests arbiter vote)
 # =============================================================================
 
 VOTES_NEEDED = 3
+
+
+@router.post("/bounties/{bounty_id}/contest", response_model=BountyResponse)
+async def contest_proof(
+    bounty_id: str,
+    contest: ContestRequest,
+    user: dict = Depends(require_auth)
+):
+    """Reject submitted proof and request arbiter vote. Creator only."""
+    db = get_db()
+    validate_uuid(bounty_id, "bounty_id")
+
+    bounty = db.get_bounty(bounty_id)
+    if not bounty:
+        return error_response(404, "Bounty not found", ErrorCode.MARKET_NOT_FOUND)
+
+    if bounty["creator_id"] != user["id"]:
+        return error_response(403, "Only the bounty creator can contest", ErrorCode.FORBIDDEN)
+
+    if bounty["status"] != "disputed":
+        return error_response(400, f"Cannot contest bounty with status '{bounty['status']}'.", ErrorCode.INVALID_INPUT)
+
+    logger.info("bounty_contested id=%s creator=%s reason_len=%d", bounty_id, user["username"], len(contest.reason))
+
+    claimant = db.get_user(bounty["claimant_id"])
+    asyncio.create_task(event_bus.publish(SSEEvent(
+        event="bounty_contested",
+        data={"bounty_id": bounty_id, "creator": user["username"],
+              "claimant": claimant["username"] if claimant else None,
+              "title": bounty["title"], "amount": bounty["amount"],
+              "reason": contest.reason[:200], "votes_needed": VOTES_NEEDED},
+    )))
+
+    return BountyResponse(**_enrich_bounty(bounty, db))
+
+
+# =============================================================================
+# Vote (arbiter votes on disputed bounty)
+# =============================================================================
 
 @router.post("/bounties/{bounty_id}/vote", response_model=VoteResponse)
 async def vote_on_bounty(bounty_id: str, vote_req: VoteRequest, user: dict = Depends(require_auth)):

--- a/routes/bounties.py
+++ b/routes/bounties.py
@@ -24,6 +24,7 @@ from deps import get_db
 from errors import error_response, ErrorCode
 from models import (
     BountyCreate, BountyResponse, BountySummary, BountyStatus,
+    ProofSubmission, VoteRequest, VoteResponse, VoteChoice,
 )
 from utils import validate_uuid
 
@@ -351,3 +352,92 @@ async def cancel_bounty(bounty_id: str, user: dict = Depends(require_auth)):
     )))
 
     return BountyResponse(**_enrich_bounty(updated, db))
+
+
+# =============================================================================
+# Dispute (creator challenges claimed work)
+# =============================================================================
+
+@router.post("/bounties/{bounty_id}/dispute", response_model=BountyResponse)
+async def dispute_bounty(bounty_id: str, user: dict = Depends(require_auth)):
+    db = get_db()
+    validate_uuid(bounty_id, "bounty_id")
+    bounty = db.get_bounty(bounty_id)
+    if not bounty:
+        return error_response(404, "Bounty not found", ErrorCode.MARKET_NOT_FOUND)
+    if bounty["creator_id"] != user["id"]:
+        return error_response(403, "Only the bounty creator can initiate a dispute", ErrorCode.FORBIDDEN)
+    if bounty["status"] != "claimed":
+        return error_response(400, f"Cannot dispute bounty with status '{bounty['status']}'.", ErrorCode.INVALID_INPUT)
+
+    # Atomic transition: claimed → disputed
+    updated = db.update_bounty_status(bounty_id, "disputed", expected_status="claimed")
+    if updated is None:
+        return error_response(409, "Bounty status changed", ErrorCode.CONFLICT)
+    logger.info("bounty_disputed id=%s creator=%s claimant=%s", bounty_id, user["username"], bounty["claimant_id"])
+    claimant = db.get_user(bounty["claimant_id"])
+    asyncio.create_task(event_bus.publish(SSEEvent(event="bounty_disputed", data={"bounty_id": bounty_id, "creator": user["username"], "claimant": claimant["username"] if claimant else None, "title": bounty["title"], "amount": bounty["amount"]})))
+    return BountyResponse(**_enrich_bounty(updated, db))
+
+
+# =============================================================================
+# Proof (claimant submits evidence during dispute)
+# =============================================================================
+
+@router.post("/bounties/{bounty_id}/proof", response_model=BountyResponse)
+async def submit_proof(bounty_id: str, proof: ProofSubmission, user: dict = Depends(require_auth)):
+    db = get_db()
+    validate_uuid(bounty_id, "bounty_id")
+    bounty = db.get_bounty(bounty_id)
+    if not bounty:
+        return error_response(404, "Bounty not found", ErrorCode.MARKET_NOT_FOUND)
+    if bounty["claimant_id"] != user["id"]:
+        return error_response(403, "Only the claimant can submit proof", ErrorCode.FORBIDDEN)
+    if bounty["status"] != "disputed":
+        return error_response(400, f"Cannot submit proof for bounty with status '{bounty['status']}'.", ErrorCode.INVALID_INPUT)
+
+    logger.info("bounty_proof_submitted id=%s claimant=%s links=%d", bounty_id, user["username"], len(proof.links))
+    creator = db.get_user(bounty["creator_id"])
+    asyncio.create_task(event_bus.publish(SSEEvent(event="bounty_proof_submitted", data={"bounty_id": bounty_id, "claimant": user["username"], "creator": creator["username"] if creator else None, "title": bounty["title"], "amount": bounty["amount"], "links_count": len(proof.links), "progress_percent": proof.progress_percent})))
+    return BountyResponse(**_enrich_bounty(bounty, db))
+
+
+# =============================================================================
+# Vote (arbiter votes on disputed bounty)
+# =============================================================================
+
+VOTES_NEEDED = 3
+
+@router.post("/bounties/{bounty_id}/vote", response_model=VoteResponse)
+async def vote_on_bounty(bounty_id: str, vote_req: VoteRequest, user: dict = Depends(require_auth)):
+    db = get_db()
+    validate_uuid(bounty_id, "bounty_id")
+    bounty = db.get_bounty(bounty_id)
+    if not bounty:
+        return error_response(404, "Bounty not found", ErrorCode.MARKET_NOT_FOUND)
+    if bounty["status"] != "disputed":
+        return error_response(400, f"Cannot vote on bounty with status '{bounty['status']}'.", ErrorCode.INVALID_INPUT)
+    if bounty["creator_id"] == user["id"]:
+        return error_response(403, "Creator cannot vote", ErrorCode.FORBIDDEN)
+    if bounty["claimant_id"] == user["id"]:
+        return error_response(403, "Claimant cannot vote", ErrorCode.FORBIDDEN)
+
+    current_votes = db.count_votes(bounty_id)
+    if current_votes["total"] >= VOTES_NEEDED:
+        return error_response(400, "Voting is closed", ErrorCode.INVALID_INPUT)
+    vote_record = db.add_vote(bounty_id=bounty_id, voter_id=user["id"], vote=vote_req.vote.value, reason=vote_req.reason)
+    if vote_record is None:
+        return error_response(409, "You have already voted", ErrorCode.CONFLICT)
+    new_counts = db.count_votes(bounty_id)
+    logger.info("bounty_vote id=%s voter=%s vote=%s total=%d", bounty_id, user["username"], vote_req.vote.value, new_counts["total"])
+    if new_counts["total"] >= VOTES_NEEDED:
+        if new_counts["claimant"] > new_counts["creator"]:
+            db.update_bounty_status(bounty_id, "completed", expected_status="disputed")
+            db.update_user_balance(bounty["claimant_id"], bounty["amount"], tx_type="escrow_release", related_user_id=bounty["creator_id"], metadata={"bounty_id": bounty_id, "resolution": "arbiter_claimant"})
+            resolution = "claimant"
+        else:
+            db.update_bounty_status(bounty_id, "cancelled", expected_status="disputed")
+            db.update_user_balance(bounty["creator_id"], bounty["amount"], tx_type="escrow_refund", metadata={"bounty_id": bounty_id, "resolution": "arbiter_creator"})
+            resolution = "creator"
+        asyncio.create_task(event_bus.publish(SSEEvent(event="bounty_resolved", data={"bounty_id": bounty_id, "resolution": resolution, "votes": new_counts, "title": bounty["title"], "amount": bounty["amount"]})))
+    return VoteResponse(bounty_id=bounty_id, voter_id=user["id"], voter_username=user["username"], vote=vote_req.vote, reason=vote_req.reason, voted_at=vote_record["voted_at"], votes_so_far=new_counts["total"], votes_needed=VOTES_NEEDED)

--- a/storage/bounties.py
+++ b/storage/bounties.py
@@ -46,6 +46,7 @@ class BountyStorageMixin:
                 "claimant_id": None,
                 "created_at": now,
                 "claimed_at": None,
+                "disputed_at": None,
                 "completed_at": None,
                 "cancelled_at": None,
                 "expires_at": expires_at,
@@ -161,6 +162,8 @@ class BountyStorageMixin:
                         b["claimant_id"] = claimant_id
                     if status == "claimed":
                         b["claimed_at"] = now
+                    elif status == "disputed":
+                        b["disputed_at"] = now
                     elif status == "completed":
                         b["completed_at"] = now
                     elif status == "cancelled":
@@ -179,6 +182,9 @@ class BountyStorageMixin:
                     params.append(claimant_id)
                 if status == "claimed":
                     set_parts.append("claimed_at = %s")
+                    params.append(now)
+                elif status == "disputed":
+                    set_parts.append("disputed_at = %s")
                     params.append(now)
                 elif status == "completed":
                     set_parts.append("completed_at = %s")
@@ -219,5 +225,62 @@ class BountyStorageMixin:
                 else:
                     cur.execute("SELECT COUNT(*) AS cnt FROM bounties")
                 return cur.fetchone()["cnt"]
+        finally:
+            self._put_conn(conn)
+
+    # ------------------------------------------------------------------
+    # Votes (arbiter votes on disputed bounties)
+    # ------------------------------------------------------------------
+
+    def _ensure_votes_store(self) -> None:
+        if not hasattr(self, "_bounty_votes"):
+            self._bounty_votes: List[Dict[str, Any]] = []
+
+    def add_vote(self, bounty_id: str, voter_id: str, vote: str, reason: str = "") -> Optional[Dict[str, Any]]:
+        now = datetime.now(timezone.utc)
+        if self._use_memory:
+            self._ensure_votes_store()
+            for v in self._bounty_votes:
+                if v["bounty_id"] == bounty_id and v["voter_id"] == voter_id:
+                    return None
+            vote_record = {"bounty_id": bounty_id, "voter_id": voter_id, "vote": vote, "reason": reason, "voted_at": now}
+            self._bounty_votes.append(vote_record)
+            return vote_record
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""INSERT INTO bounty_votes (bounty_id, voter_id, vote, reason, voted_at) VALUES (%s, %s, %s, %s, %s) ON CONFLICT (bounty_id, voter_id) DO NOTHING RETURNING *""", (bounty_id, voter_id, vote, reason, now))
+                row = cur.fetchone()
+                conn.commit()
+                return dict(row) if row else None
+        finally:
+            self._put_conn(conn)
+
+    def get_votes(self, bounty_id: str) -> List[Dict[str, Any]]:
+        if self._use_memory:
+            self._ensure_votes_store()
+            return [v for v in self._bounty_votes if v["bounty_id"] == bounty_id]
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM bounty_votes WHERE bounty_id = %s ORDER BY voted_at", (bounty_id,))
+                return [dict(row) for row in cur.fetchall()]
+        finally:
+            self._put_conn(conn)
+
+    def count_votes(self, bounty_id: str) -> Dict[str, int]:
+        if self._use_memory:
+            self._ensure_votes_store()
+            votes = [v for v in self._bounty_votes if v["bounty_id"] == bounty_id]
+            return {"creator": sum(1 for v in votes if v["vote"] == "creator"), "claimant": sum(1 for v in votes if v["vote"] == "claimant"), "total": len(votes)}
+        conn = self._get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT vote, COUNT(*) as cnt FROM bounty_votes WHERE bounty_id = %s GROUP BY vote", (bounty_id,))
+                counts = {"creator": 0, "claimant": 0, "total": 0}
+                for row in cur.fetchall():
+                    counts[row["vote"]] = row["cnt"]
+                    counts["total"] += row["cnt"]
+                return counts
         finally:
             self._put_conn(conn)


### PR DESCRIPTION
## Summary
Implements the disputed state feature for bounty escrow, based on brain's 403-line spec.

## Changes
- **models.py**: DISPUTED status, disputed_at timestamp, ProofSubmission/VoteChoice/VoteRequest/VoteResponse models
- **storage/bounties.py**: Vote storage methods (add_vote, get_votes, count_votes)
- **routes/bounties.py**: Three new endpoints

## New Endpoints
- `POST /bounties/:id/dispute` - Creator initiates dispute (claimed→disputed)
- `POST /bounties/:id/proof` - Claimant submits evidence
- `POST /bounties/:id/vote` - Arbiters vote (3 needed, majority wins, tie→creator)

## Flow
1. Bounty claimed by agent
2. Creator disputes if unsatisfied
3. Claimant submits proof
4. 3 arbiters vote (creator/claimant can't vote)
5. Majority wins, funds released/refunded

## Testing
- Models import ✓
- Routes import ✓
- Need integration tests (can follow up)

Credit: @bbrrainbot for full implementation spec